### PR TITLE
Add missing checks to vdc, vdcuser and account templates

### DIFF
--- a/templates/account/README.md
+++ b/templates/account/README.md
@@ -11,7 +11,7 @@ This template is responsible for creating an account on any openVCloud environme
 - `maxMemoryCapacity`: The limit on the memory capacity that can be used by the account. Default to -1 (unlimited).
 - `maxCPUCapacity`: The limit on the CPUs that can be used by the account. Default: -1 (unlimited).
 - `maxNumPublicIP`: The limit on the number of public IPs that can be used by the account. Default to -1 (unlimited).
-- `maxDiskCapacity`: The limit on the disk capacity that can be used by the account. Default to -1 (unlimited).
+- `maxVDiskCapacity`: The limit on the disk capacity that can be used by the account. Default to -1 (unlimited).
 - `consumptionFrom`: determines the start date of the required period to fetch the account consumption info from. If left empty will be creation time of the account.
 - `consumptionTo`: determines the end date of the required period to fetch the account consumption info from. If left empty will be `consumptionfrom` + 1 hour.
 - `consumptionData`: consumption data will be saved here as series of bytes which represents a zip file.
@@ -39,7 +39,7 @@ For information about the different access rights, check docs at [openvcloud](ht
   - `maxMemoryCapacity`
   - `maxCPUCapacity`
   - `maxNumPublicIP`
-  - `maxDiskCapacity`
+  - `maxVDiskCapacity`
 
 ```yaml
 services:

--- a/templates/account/README.md
+++ b/templates/account/README.md
@@ -6,18 +6,18 @@ This template is responsible for creating an account on any openVCloud environme
 
 ## Schema
 
-- `openvcloud`: Name of the [openvcloud](../openvcloud) instance used to connect to the environment.  **required**
-- `description`: Arbitrary description of the account. **optional**
-- `maxMemoryCapacity`: The limit on the memory capacity that can be used by the account. Default to -1 (unlimited)
-- `maxCPUCapacity`: The limit on the CPUs that can be used by the account. Default: -1 (unlimited)
-- `maxNumPublicIP`: The limit on the number of public IPs that can be used by the account. Default to -1 (unlimited)
-- `maxDiskCapacity`: The limit on the disk capacity that can be used by the account. Default to -1 (unlimited)
+- `openvcloud`: Name of the [openvcloud](../openvcloud) instance used to connect to the environment.  **Required**.
+- `description`: Arbitrary description of the account. **Optional**.
+- `maxMemoryCapacity`: The limit on the memory capacity that can be used by the account. Default to -1 (unlimited).
+- `maxCPUCapacity`: The limit on the CPUs that can be used by the account. Default: -1 (unlimited).
+- `maxNumPublicIP`: The limit on the number of public IPs that can be used by the account. Default to -1 (unlimited).
+- `maxDiskCapacity`: The limit on the disk capacity that can be used by the account. Default to -1 (unlimited).
 - `consumptionFrom`: determines the start date of the required period to fetch the account consumption info from. If left empty will be creation time of the account.
 - `consumptionTo`: determines the end date of the required period to fetch the account consumption info from. If left empty will be `consumptionfrom` + 1 hour.
-- `consumptionData`: consumption data will be saved here as series of bytes which represents a zip file. Example of writing the data:
+- `consumptionData`: consumption data will be saved here as series of bytes which represents a zip file.
 - `create`: defines whether account can be created or deleted. Default to `True`.
-- `users`: List of [vcd users](#vdc-user)  authorized on the account. **Filled in automatically, don't specify it in the blueprint**
-- `accountID`: The ID of the account. **Filled in automatically, don't specify it in the blueprint**
+- `users`: List of [vcd users](#vdc-user)  authorized on the account. **Filled in automatically, don't specify it in the blueprint**.
+- `accountID`: The ID of the account. **Filled in automatically, don't specify it in the blueprint**.
 
 ### Vdc User
 
@@ -32,7 +32,7 @@ For information about the different access rights, check docs at [openvcloud](ht
 
 - `install`: creates an account or gets an existent account.
 - `uninstall`: delete an account. All VDCs (Virtual Data Centers) related to this account will be destroyed and uninstall should not be called on those VDC services when uninstalling an account.
-- `user_add`: adds a user to the account or updates access rights.
+- `user_add`: adds a user to the account or updates access rights. In order to add a user, corresponding [`vdcuser`](#vdc-user) service should be installed.
 - `user_delete`: deletes a user from the account.
 - `update`: updates the account attributes:
 

--- a/templates/account/account.py
+++ b/templates/account/account.py
@@ -53,12 +53,15 @@ class Account(TemplateBase):
         return self.data['openvcloud']
 
     def install(self):
+        '''
+        Install account
+        '''
+        
         try:
             self.state.check('actions', 'install', 'ok')
             return
         except StateCheckError:
             pass
-
 
         # Set limits
         # if account does not exist, it will create it, 
@@ -73,6 +76,7 @@ class Account(TemplateBase):
         )
 
         self.data['accountID'] = self.account.model['id']
+
         # get list of authorized users
         self.get_users(refresh=False)
 
@@ -88,7 +92,7 @@ class Account(TemplateBase):
     def uninstall(self):
         if not self.data['create']:
             raise RuntimeError('readonly account')
-        self.state.check('actions', 'install', 'ok')
+
         acc = self.ovc.account_get(self.name, create=False)
         acc.delete()
 
@@ -106,7 +110,7 @@ class Account(TemplateBase):
 
         # check that username is given 
         if not user.get('name'):
-            raise KeyError("failed to add user, field 'name' is required")
+            raise ValueError("failed to add user, field 'name' is required")
 
         # derive service name from username
         service_name = user['name'].split('@')[0]
@@ -116,10 +120,7 @@ class Account(TemplateBase):
             raise ValueError('no vdcuser service found with name "%s"' % service_name)
 
         # check that user was successfully installed
-        try:
-            find[0].state.check('actions', 'install', 'ok')
-        except StateCheckError:
-            raise StateCheckError('service for vdcuser "%s" in not installed' % service_name)
+        find[0].state.check('actions', 'install', 'ok')
 
         self.get_users()
         users = self.data['users']
@@ -166,8 +167,6 @@ class Account(TemplateBase):
                     users.remove(user)
                     break
                 raise RuntimeError('failed to remove user "%s"' % username)
-        else:
-            raise RuntimeError('user "%s" is not found' % username)
 
     def update(self, maxMemoryCapacity=None, maxDiskCapacity=None,
                maxNumPublicIP=None, maxCPUCapacity=None):

--- a/templates/account/account.py
+++ b/templates/account/account.py
@@ -141,6 +141,9 @@ class Account(TemplateBase):
         Delete user access
         :param username: user instance name
         '''
+
+        self.state.check('actions', 'install', 'ok')
+
         if not self.data['create']:
             raise RuntimeError('readonly account')
 
@@ -167,6 +170,9 @@ class Account(TemplateBase):
         :param maxNumPublicIP: The limit on the number of public IPs that can be used by the account.
         :param maxDiskCapacity: The limit on the disk capacity that can be used by the account.
         '''
+
+        self.state.check('actions', 'install', 'ok')
+        
         if not self.data['create']:
             raise RuntimeError('readonly account')
 

--- a/templates/account/account.py
+++ b/templates/account/account.py
@@ -108,7 +108,7 @@ class Account(TemplateBase):
 
         find = self.api.services.find(template_uid=self.VDCUSER_TEMPLATE, name=user['name'])
         if len(find) != 1:
-            raise ValueError('no account service found with name "%s"', user['name'])
+            raise ValueError('no vdcuser service found with name "%s"' % user['name'])
 
         # check that user was successfully installed
         try:

--- a/templates/account/account.py
+++ b/templates/account/account.py
@@ -70,7 +70,7 @@ class Account(TemplateBase):
             name=self.name,
             create=self.data['create'],
             maxMemoryCapacity=self.data['maxMemoryCapacity'],
-            maxVDiskCapacity=self.data['maxDiskCapacity'],
+            maxVDiskCapacity=self.data['maxVDiskCapacity'],
             maxCPUCapacity=self.data['maxCPUCapacity'],
             maxNumPublicIP=self.data['maxNumPublicIP'],
         )
@@ -82,7 +82,7 @@ class Account(TemplateBase):
 
         # update capacity in case account already existed
         self.account.model['maxMemoryCapacity'] = self.data['maxMemoryCapacity']
-        self.account.model['maxVDiskCapacity'] = self.data['maxDiskCapacity']
+        self.account.model['maxVDiskCapacity'] = self.data['maxVDiskCapacity']
         self.account.model['maxNumPublicIP'] = self.data['maxNumPublicIP']
         self.account.model['maxCPUCapacity'] = self.data['maxCPUCapacity']
         self.account.save()
@@ -168,15 +168,15 @@ class Account(TemplateBase):
                     break
                 raise RuntimeError('failed to remove user "%s"' % username)
 
-    def update(self, maxMemoryCapacity=None, maxDiskCapacity=None,
+    def update(self, maxMemoryCapacity=None, maxVDiskCapacity=None,
                maxNumPublicIP=None, maxCPUCapacity=None):
         '''
         Update account flags
 
         :param maxMemoryCapacity: The limit on the memory capacity that can be used by the account
-        :param maxCPUCapacity: The limit on the CPUs that can be used by the account.
+        :param maxVDiskCapacity: The limit on the disk capacity that can be used by the account.
         :param maxNumPublicIP: The limit on the number of public IPs that can be used by the account.
-        :param maxDiskCapacity: The limit on the disk capacity that can be used by the account.
+        :param maxCPUCapacity: The limit on the CPUs that can be used by the account.
         '''
 
         self.state.check('actions', 'install', 'ok')
@@ -191,7 +191,7 @@ class Account(TemplateBase):
         cl = self.ovc
         account = cl.account_get(name=self.name, create=False)
 
-        for key in ['maxMemoryCapacity', 'maxDiskCapacity',
+        for key in ['maxMemoryCapacity', 'maxVDiskCapacity',
                     'maxNumPublicIP', 'maxCPUCapacity']:
             value = kwargs[key]
             if value is None:

--- a/templates/account/account.py
+++ b/templates/account/account.py
@@ -106,6 +106,12 @@ class Account(TemplateBase):
         if len(find) != 1:
             raise ValueError('no account service found with name "%s"', user['name'])
 
+        # check that user was successfully installed
+        try:
+            find[0].state.check('actions', 'install', 'ok')
+        except StateCheckError:
+            raise StateCheckError('service for vdcuser "%s" in not installed' % user['name'])
+
         self.get_users()
         users = self.data['users']
 

--- a/templates/account/account.py
+++ b/templates/account/account.py
@@ -108,7 +108,7 @@ class Account(TemplateBase):
         if not user.get('name'):
             raise KeyError("failed to add user, field 'name' is required")
 
-        # derice service name from username
+        # derive service name from username
         service_name = user['name'].split('@')[0]
 
         find = self.api.services.find(template_uid=self.VDCUSER_TEMPLATE, name=service_name)

--- a/templates/account/account.py
+++ b/templates/account/account.py
@@ -22,7 +22,7 @@ class Account(TemplateBase):
         ovcs = self.api.services.find(template_uid=self.OVC_TEMPLATE, name=self.data['openvcloud'])
 
         if len(ovcs) != 1:
-            raise RuntimeError('found %s openvcloud connections, requires exactly 1' % len(ovcs))
+            raise RuntimeError('found %s openvcloud connections with name "%s", requires exactly 1' % (len(ovcs), self.data['openvcloud']))
 
     @property
     def ovc(self):

--- a/templates/account/account.py
+++ b/templates/account/account.py
@@ -102,6 +102,10 @@ class Account(TemplateBase):
         if not self.data['create']:
             raise RuntimeError('readonly account')
 
+        # check that username is given 
+        if 'name' not in user.keys():
+            raise KeyError("failed to add user, field 'name' is required")
+
         find = self.api.services.find(template_uid=self.VDCUSER_TEMPLATE, name=user['name'])
         if len(find) != 1:
             raise ValueError('no account service found with name "%s"', user['name'])
@@ -172,7 +176,7 @@ class Account(TemplateBase):
         '''
 
         self.state.check('actions', 'install', 'ok')
-        
+
         if not self.data['create']:
             raise RuntimeError('readonly account')
 

--- a/templates/account/schema.capnp
+++ b/templates/account/schema.capnp
@@ -24,7 +24,7 @@ struct Schema {
 	maxNumPublicIP @6 :Int64 = -1;
 
 	# The limit on the disk capacity that can be used by the account. Default: -1 (unlimited)
-	maxDiskCapacity @7 :Int64 = -1;
+	maxVDiskCapacity @7 :Int64 = -1;
 
 	# determines the start date of the required period to fetch the account consumption info from. If left empty will be creation time of the account.
 	consumptionFrom @8 :Int64;

--- a/templates/account/test_account.py
+++ b/templates/account/test_account.py
@@ -20,7 +20,7 @@ class TestAccount(TestCase):
 
         # define properties of account mock
         acc_mock =  MagicMock(model={'acl': []})
-        self.ovc_mock = MagicMock(account_get=MagicMock(return_value=acc_mock))        
+        self.ovc_mock = MagicMock(account_get=MagicMock(return_value=acc_mock))      
 
     def test_validate_openvcloud(self):
         data = {
@@ -142,6 +142,32 @@ class TestAccount(TestCase):
 
         account = cl.account_get.return_value
         account.save.assert_called_once_with()
+
+    @mock.patch.object(j.clients, '_openvcloud')
+    def test_uninstall(self, ovc):
+        '''
+        Test uninstall account
+        '''
+        # test error in read-only cloudspace
+        data_read_only = {
+            'openvcloud': 'connection',
+            'create': False,
+            }
+        instance = self.type('test', None, data_read_only)
+
+        with pytest.raises(RuntimeError,
+                           message='"%s" is readonly cloudspace' % instance.name):
+            instance.uninstall()
+
+        # test success
+        data = {
+            'openvcloud': 'connection',
+            }
+
+        account = ovc.get.return_value.account_get.return_value
+        instance = self.type('test', None, data)
+        instance.uninstall()
+        account.delete.assert_called_once_with()     
 
     def test_user_add(self):
         '''

--- a/templates/account/test_account.py
+++ b/templates/account/test_account.py
@@ -237,16 +237,12 @@ class TestAccount(TestCase):
                 with pytest.raises(RuntimeError,
                                    message='failed to remove user "%s"' % username):
                     instance.user_delete(username)
-                
-                # test deliting nonexistent user
-                instance.account.unauthorize_user.reset_mock()
-                nonexistent_username = 'nonexistent_username'
-                with pytest.raises(RuntimeError,
-                                   message='user "%s" is not found' % nonexistent_username):
-                    instance.user_delete(nonexistent_username)
 
     @mock.patch.object(j.clients, '_openvcloud')
     def test_update(self, openvcloud):
+        '''
+        Test updating account limits
+        '''
         cl = openvcloud.get.return_value
         account = cl.account_get.return_value
         account.model = {}
@@ -260,7 +256,7 @@ class TestAccount(TestCase):
 
         instance.update(
             maxMemoryCapacity=1,
-            maxDiskCapacity=2,
+            maxVDiskCapacity=2,
             maxNumPublicIP=3
         )
 
@@ -268,6 +264,6 @@ class TestAccount(TestCase):
 
         self.assertEqual(account.model, {
             'maxMemoryCapacity': 1,
-            'maxDiskCapacity': 2,
+            'maxVDiskCapacity': 2,
             'maxNumPublicIP': 3
         })

--- a/templates/openvcloud/README.md
+++ b/templates/openvcloud/README.md
@@ -1,27 +1,24 @@
 
 # template: openvcloud
 
-## Description:
-This template is responsible for configuring an openvcloud connection
+## Description
 
-## Schema:
+This template is responsible for configuring an OpenvCloud connection.
 
-- description: Arbitrary description of the account. **Optional**
-- address: dns name of the openvcloud env
-- port: (optional) API port, default to 443
-- login: Username of the connection
-- token: Itsyou.online JWT token
-- location: environment to connect to
+## Schema
+
+- `address`: dns name of the openvcloud env. **Required**.
+- `token`: Itsyou.online JWT token. **Required**.
+- `location`: environment to connect to. **Required**.
+- `port`: API port. Default to 443.
+- `description`: Arbitrary description of the account. **Optional**.
 
 ## Example for creating a connection
+
 ```yaml
 services:
-    - github.com/openvcloud/0-templates/sshkey/0.0.1__<keyName>:
-        dir: '/root/.ssh/'
-        passphrase: <passphrase>
     - github.com/openvcloud/0-templates/openvcloud/0.0.1__be-gen-1:
         location: be-gen-1
         address: 'be-gen-1.demo.greenitglobe.com'
-        login: '<username>'
         token: '<jwt token>'
 ```

--- a/templates/vdc/README.md
+++ b/templates/vdc/README.md
@@ -31,8 +31,8 @@ For information about the different access rights check docs at [openvcloud](htt
 - `user_delete`: unauthorize user.
 - `enable`: enable VDC.
 - `disable`: disable VDC.
-- `portforward_create`: create a portforward.
-- `portforward_delete`: delete a portforward.
+- `portforward_create`: create a portforward. Expected to be called from [`node` service](../node).
+- `portforward_delete`: delete a portforward. Expected to be called from [`node` service](../node).
 - `update`: update limits of the VDC.
 
 ```yaml
@@ -114,6 +114,7 @@ actions:
     service: myspace
     actions: ['portforward_create']
     args:
+      machineId: 2342
       port_forwards:
         - destination: <local port>
           source: <public port>
@@ -125,6 +126,7 @@ actions:
     service: myspace
     actions: ['portforward_delete']
     args:
+      machineId: 2342
       port_forwards:
         - destination: <local port>
           source: <public port>

--- a/templates/vdc/README.md
+++ b/templates/vdc/README.md
@@ -11,7 +11,7 @@ This actor template creates a VDC (Virtual Data Center) on the specified environ
 - `create`: defines whether VDC can be created or deleted. Default to `True`.
 - `maxMemoryCapacity`: Cloudspace limits, maximum memory(GB).
 - `maxCPUCapacity`: Cloudspace limits, maximum CPU capacity.
-- `maxDiskCapacity`: Cloudspace limits, maximum disk capacity(GB).
+- `maxVDiskCapacity`: Cloudspace limits, maximum disk capacity(GB).
 - `maxNumPublicIP`: Cloudspace limits, maximum allowed number of public IPs.
 - `externalNetworkID`: External network to be attached to this cloudspace.
 - `maxNetworkPeerTransfer`: Cloudspace limits, max sent/received network transfer peering(GB).
@@ -81,7 +81,7 @@ actions:
     args:
       maxMemoryCapacity: 5
       maxCPUCapacity: 1
-      maxDiskCapacity: 20
+      maxVDiskCapacity: 20
       maxNumPublicIP: 1
       externalNetworkID: -1
       maxNetworkPeerTransfer: 10

--- a/templates/vdc/schema.capnp
+++ b/templates/vdc/schema.capnp
@@ -18,7 +18,7 @@ struct Schema {
 	maxCPUCapacity @4 :Int64 = -1;
 
 	# Cloudspace limits, maximum disk capacity(GB), optional.
-	maxDiskCapacity @5 :Int64 = -1;
+	maxVDiskCapacity @5 :Int64 = -1;
 
 	# Cloudspace limits, maximum allowed number of public IPs, optional.
 	maxNumPublicIP @6 :Int64 = -1;

--- a/templates/vdc/test_vdc.py
+++ b/templates/vdc/test_vdc.py
@@ -254,17 +254,11 @@ class TestVDC(TestCase):
                 with pytest.raises(RuntimeError,
                                    message='failed to update accesstype of user "test1"'):
                     instance.user_delete(username)
-                
-                # test deliting nonexistent user
-                instance.space.unauthorize_user.reset_mock()
-                nonexistent_username = 'nonexistent_username'
-                with pytest.raises(RuntimeError,
-                                   message='user "%s" is not found' % nonexistent_username):
-                    instance.user_delete(nonexistent_username)
-                
-
 
     def test_update(self):
+        '''
+        Test updating vdc limits
+        '''
         instance = self.type('test', None, {})
 
         with self.assertRaises(StateCheckError):
@@ -277,7 +271,7 @@ class TestVDC(TestCase):
             space.model = {}
             instance.update(
                 maxMemoryCapacity=1,
-                maxDiskCapacity=2,
+                maxVDiskCapacity=25,
                 maxNumPublicIP=3,
                 maxCPUCapacity=4
             )
@@ -286,7 +280,7 @@ class TestVDC(TestCase):
 
             self.assertEqual(space.model, {
                 'maxMemoryCapacity': 1,
-                'maxDiskCapacity': 2,
+                'maxVDiskCapacity': 25,
                 'maxNumPublicIP': 3,
                 'maxCPUCapacity': 4
             })

--- a/templates/vdc/vdc.py
+++ b/templates/vdc/vdc.py
@@ -196,7 +196,7 @@ class Vdc(TemplateBase):
         space.disable('The space should be disabled.')
         self.data['disabled'] = True
 
-    def portforward_create(self, machineId=None, port_forwards=[], protocol='tcp'):
+    def portforward_create(self, machineId, port_forwards=[], protocol='tcp'):
         """
         Create port forwards
         """
@@ -216,7 +216,7 @@ class Vdc(TemplateBase):
                 machineId=machineId,
                 )
 
-    def portforward_delete(self, machineId=None, port_forwards=[], protocol='tcp'):
+    def portforward_delete(self, machineId, port_forwards=[], protocol='tcp'):
         """
         Delete port forwards
         """

--- a/templates/vdc/vdc.py
+++ b/templates/vdc/vdc.py
@@ -241,6 +241,12 @@ class Vdc(TemplateBase):
         if len(find) != 1:
             raise ValueError('no vdcuser service found with name "%s"', user['name'])
 
+        # check that user was successfully installed
+        try:
+            find[0].state.check('actions', 'install', 'ok')
+        except StateCheckError:
+            raise StateCheckError('service for vdcuser "%s" in not installed' % user['name'])
+        
         # fetch list of authorized users to self.data['users']
         self.get_users()
         users = self.data['users']

--- a/templates/vdc/vdc.py
+++ b/templates/vdc/vdc.py
@@ -91,6 +91,7 @@ class Vdc(TemplateBase):
         '''
         Install vdc. Will be created if doesn't exist
         '''
+
         try:
             self.state.check('actions', 'install', 'ok')
             return
@@ -150,12 +151,10 @@ class Vdc(TemplateBase):
         '''
         Delete VDC
         '''
-        self.state.check('actions', 'install', 'ok')
-
         if not self.data['create']:
             raise RuntimeError('readonly cloudspace')
-        space = self.account.space_get(self.name)
-        space.delete()
+
+        self.space.delete()
 
         self.state.delete('actions', 'install')
 
@@ -255,7 +254,7 @@ class Vdc(TemplateBase):
 
         # check that username is given 
         if not user.get('name'):
-            raise KeyError("failed to add user, field 'name' is required")
+            raise ValueError("failed to add user, field 'name' is required")
 
         # derive service name from username
         service_name = user['name'].split('@')[0]
@@ -265,10 +264,7 @@ class Vdc(TemplateBase):
             raise ValueError('no vdcuser service found with name "%s"', user['name'])
 
         # check that user was successfully installed
-        try:
-            find[0].state.check('actions', 'install', 'ok')
-        except StateCheckError:
-            raise StateCheckError('service for vdcuser "%s" in not installed' % service_name)
+        find[0].state.check('actions', 'install', 'ok')
         
         # fetch list of authorized users to self.data['users']
         self.get_users()
@@ -308,8 +304,6 @@ class Vdc(TemplateBase):
         if not self.data['create']:
             raise RuntimeError('readonly cloudspace')
 
-        self.state.check('actions', 'install', 'ok')
-
         # fetch list of authorized users to self.data['users']
         self.get_users()
         users = self.data['users']
@@ -320,8 +314,6 @@ class Vdc(TemplateBase):
                     break
                 else:
                     raise RuntimeError('failed to delete user "%s"' % username)
-        else:
-            raise RuntimeError('user "%s" is not found' % username)
 
     def update(self, maxMemoryCapacity=None, maxDiskCapacity=None, maxNumPublicIP=None,
                maxCPUCapacity=None, maxNetworkPeerTransfer=None):

--- a/templates/vdc/vdc.py
+++ b/templates/vdc/vdc.py
@@ -254,10 +254,13 @@ class Vdc(TemplateBase):
             raise RuntimeError('readonly cloudspace')
 
         # check that username is given 
-        if 'name' not in user.keys():
+        if not user.get('name'):
             raise KeyError("failed to add user, field 'name' is required")
 
-        find = self.api.services.find(template_uid=self.VDCUSER_TEMPLATE, name=user['name'])
+        # derive service name from username
+        service_name = user['name'].split('@')[0]
+
+        find = self.api.services.find(template_uid=self.VDCUSER_TEMPLATE, name=service_name)
         if len(find) != 1:
             raise ValueError('no vdcuser service found with name "%s"', user['name'])
 
@@ -265,7 +268,7 @@ class Vdc(TemplateBase):
         try:
             find[0].state.check('actions', 'install', 'ok')
         except StateCheckError:
-            raise StateCheckError('service for vdcuser "%s" in not installed' % user['name'])
+            raise StateCheckError('service for vdcuser "%s" in not installed' % service_name)
         
         # fetch list of authorized users to self.data['users']
         self.get_users()

--- a/templates/vdc/vdc.py
+++ b/templates/vdc/vdc.py
@@ -115,7 +115,7 @@ class Vdc(TemplateBase):
             name=self.name,
             create=True,
             maxMemoryCapacity=self.data.get('maxMemoryCapacity', -1),
-            maxVDiskCapacity=self.data.get('maxDiskCapacity', -1),
+            maxVDiskCapacity=self.data.get('maxVDiskCapacity', -1),
             maxCPUCapacity=self.data.get('maxCPUCapacity', -1),
             maxNumPublicIP=self.data.get('maxNumPublicIP', -1),
             maxNetworkPeerTransfer=self.data.get('maxNetworkPeerTransfer', -1),
@@ -129,7 +129,7 @@ class Vdc(TemplateBase):
 
         # update capacity incase cloudspace already existed update it
         space.model['maxMemoryCapacity'] = self.data.get('maxMemoryCapacity', -1)
-        space.model['maxVDiskCapacity'] = self.data.get('maxDiskCapacity', -1)
+        space.model['maxVDiskCapacity'] = self.data.get('maxVDiskCapacity', -1)
         space.model['maxNumPublicIP'] = self.data.get('maxNumPublicIP', -1)
         space.model['maxCPUCapacity'] = self.data.get('maxCPUCapacity', -1)
         space.model['maxNetworkPeerTransfer'] = self.data.get('maxNetworkPeerTransfer', -1)
@@ -315,7 +315,7 @@ class Vdc(TemplateBase):
                 else:
                     raise RuntimeError('failed to delete user "%s"' % username)
 
-    def update(self, maxMemoryCapacity=None, maxDiskCapacity=None, maxNumPublicIP=None,
+    def update(self, maxMemoryCapacity=None, maxVDiskCapacity=None, maxNumPublicIP=None,
                maxCPUCapacity=None, maxNetworkPeerTransfer=None):
         '''
         Update account flags
@@ -323,7 +323,7 @@ class Vdc(TemplateBase):
         :param maxMemoryCapacity: The limit on the memory capacity that can be used by the account
         :param maxCPUCapacity: The limit on the CPUs that can be used by the account.
         :param maxNumPublicIP: The limit on the number of public IPs that can be used by the account.
-        :param maxDiskCapacity: The limit on the disk capacity that can be used by the account.
+        :param maxVDiskCapacity: The limit on the disk capacity that can be used by the account.
         :param maxNetworkPeerTransfer: Cloudspace limits, max sent/received network transfer peering(GB).
         '''
 
@@ -342,7 +342,7 @@ class Vdc(TemplateBase):
 
         self.data.update(kwargs)
 
-        for key in ['maxMemoryCapacity', 'maxDiskCapacity', 'maxNumPublicIP',
+        for key in ['maxMemoryCapacity', 'maxVDiskCapacity', 'maxNumPublicIP',
                     'maxCPUCapacity', 'maxNetworkPeerTransfer']:
             value = kwargs[key]
             if value is not None:

--- a/templates/vdc/vdc.py
+++ b/templates/vdc/vdc.py
@@ -202,7 +202,7 @@ class Vdc(TemplateBase):
         Create port forwards
         """
         self.state.check('actions', 'install', 'ok')
-        
+
         ovc = self.ovc
         space = self.space
 
@@ -252,6 +252,10 @@ class Vdc(TemplateBase):
 
         if not self.data['create']:
             raise RuntimeError('readonly cloudspace')
+
+        # check that username is given 
+        if 'name' not in user.keys():
+            raise KeyError("failed to add user, field 'name' is required")
 
         find = self.api.services.find(template_uid=self.VDCUSER_TEMPLATE, name=user['name'])
         if len(find) != 1:

--- a/templates/vdc/vdc.py
+++ b/templates/vdc/vdc.py
@@ -72,7 +72,7 @@ class Vdc(TemplateBase):
             return self._space
 
         acc = self.account
-        self._space = acc.space_get(name=self.name)
+        self._space = acc.space_get(name=self.name, create=False)
         return self._space
 
     def get_users(self, refresh=True):
@@ -165,7 +165,7 @@ class Vdc(TemplateBase):
         self.state.check('actions', 'install', 'ok')
 
         if not self.data['create']:
-            raise RuntimeError('readonly cloudspace')
+            raise RuntimeError('"%s" is readonly cloudspace' % self.name)
 
         # Get space, raise error if not found
         self.state.check('actions', 'install', 'ok')

--- a/templates/vdc/vdc.py
+++ b/templates/vdc/vdc.py
@@ -88,11 +88,15 @@ class Vdc(TemplateBase):
         return self.data['users']
 
     def install(self):
+        '''
+        Install vdc. Will be created if doesn't exist
+        '''
         try:
             self.state.check('actions', 'install', 'ok')
             return
         except StateCheckError:
             pass
+
         acc = self.account
         if not self.data['create']:
             space = self.space
@@ -146,15 +150,21 @@ class Vdc(TemplateBase):
         '''
         Delete VDC
         '''
+        self.state.check('actions', 'install', 'ok')
+
         if not self.data['create']:
             raise RuntimeError('readonly cloudspace')
         space = self.account.space_get(self.name)
         space.delete()
 
+        self.state.delete('actions', 'install')
+
     def enable(self):
         '''
         Enable VDC
         '''        
+        self.state.check('actions', 'install', 'ok')
+
         if not self.data['create']:
             raise RuntimeError('readonly cloudspace')
 
@@ -171,7 +181,9 @@ class Vdc(TemplateBase):
     def disable(self):
         '''
         Disable VDC
-        '''        
+        '''
+
+        self.state.check('actions', 'install', 'ok')
         if not self.data['create']:
             raise RuntimeError('readonly cloudspace')
             
@@ -189,6 +201,8 @@ class Vdc(TemplateBase):
         """
         Create port forwards
         """
+        self.state.check('actions', 'install', 'ok')
+        
         ovc = self.ovc
         space = self.space
 
@@ -207,6 +221,8 @@ class Vdc(TemplateBase):
         """
         Delete port forwards
         """
+        self.state.check('actions', 'install', 'ok')
+
         ovc = self.ovc
         space = self.space
         existent_ports = [(port['publicPort'], port['localPort'], port['id'])
@@ -280,6 +296,8 @@ class Vdc(TemplateBase):
 
         :param username: user instance name
         '''
+        self.state.check('actions', 'install', 'ok')
+
         if not self.data['create']:
             raise RuntimeError('readonly cloudspace')
 
@@ -309,6 +327,8 @@ class Vdc(TemplateBase):
         :param maxDiskCapacity: The limit on the disk capacity that can be used by the account.
         :param maxNetworkPeerTransfer: Cloudspace limits, max sent/received network transfer peering(GB).
         '''
+
+        self.state.check('actions', 'install', 'ok')
         if not self.data['create']:
             raise RuntimeError('readonly cloudspace')
         # work around not supporting the **kwargs in actions call

--- a/templates/vdcuser/README.md
+++ b/templates/vdcuser/README.md
@@ -7,22 +7,22 @@ This template represents a user on an environment. If the user doesn't exist it 
 ## Schema
 
 - openvcloud (required): Name of the [openvcloud](../openvcloud) instance used to connect to the environment.
-- password: Password of the user. (optional) is an Oauth provider is set
+- password: Password of the user. (optional) if an Oauth provider is set.
 - email: Email of the user.
 - provider: Oauth provider. Currently: itsyou.online
 - groups: Groups that the user will belong to.
 
-## Example
+## Actions
+
+- `install`: install a vdcuser. Create a vdcuser if doesn't exist.
+- `uninstall`: delete a vdcuser.
+- `groups_set`: set user groups.
 
 ```yaml
 services:
-    - github.com/openvcloud/0-templates/sshkey/0.0.1__keyname:
-        dir: '/root/.ssh/'
-        passphrase: <passphrase>
     - github.com/openvcloud/0-templates/openvcloud/0.0.1__myovc:
         location: be-gen-demo
         address: 'ovc.demo.greenitglobe.com'
-        login: '<username>'
         token: '<iyo jwt token>'
     - github.com/openvcloud/0-templates/vdcuser/0.0.1__admin:
         openvcloud: myovc
@@ -33,8 +33,7 @@ actions:
       actions: ['install']
 ```
 
-## Actions
-### `groups_set` set user groups
+
 ```yaml
 actions:
   - service: admin

--- a/templates/vdcuser/test_vdcuser.py
+++ b/templates/vdcuser/test_vdcuser.py
@@ -101,6 +101,7 @@ class TestVdcUser(TestCase):
         openvcloud.reset_mock()
         client.api.system.usermanager.userexists.return_value = False
 
+        instance.state.delete('actions', 'install')
         instance.install()
 
         client.api.system.usermanager.create.assert_called_once_with(

--- a/templates/vdcuser/test_vdcuser.py
+++ b/templates/vdcuser/test_vdcuser.py
@@ -125,13 +125,9 @@ class TestVdcUser(TestCase):
         name = 'user1'
         instance = self.type(name, None, data)
 
-        with self.assertRaises(StateCheckError):
-            instance.uninstall()
-
         client = openvcloud.get.return_value
         # user exists
         client.api.system.usermanager.userexists.return_value = True
-        instance.state.set('actions', 'install', 'ok')
         instance.uninstall()
 
         client.api.system.usermanager.userexists.assert_called_once_with(name=name)

--- a/templates/vdcuser/vdcuser.py
+++ b/templates/vdcuser/vdcuser.py
@@ -37,7 +37,7 @@ class Vdcuser(TemplateBase):
         '''
         Install vdcuser
         '''
-
+        
         try:
             self.state.check('actions', 'install', 'ok')
             return
@@ -70,9 +70,7 @@ class Vdcuser(TemplateBase):
     def uninstall(self):
         """
         unauthorize user to all consumed vdc
-        """
-        self.state.check('actions', 'install', 'ok')
-        
+        """      
         client = self.ovc
         username = self.get_fqid()
         if client.api.system.usermanager.userexists(name=username):

--- a/templates/vdcuser/vdcuser.py
+++ b/templates/vdcuser/vdcuser.py
@@ -1,6 +1,6 @@
 from js9 import j
 from zerorobot.template.base import TemplateBase
-
+from zerorobot.template.state import StateCheckError
 
 class Vdcuser(TemplateBase):
 
@@ -34,6 +34,16 @@ class Vdcuser(TemplateBase):
         return "%s@%s" % (self.name, provider) if provider else self.name
 
     def install(self):
+        '''
+        Install vdcuser
+        '''
+
+        try:
+            self.state.check('actions', 'install', 'ok')
+            return
+        except StateCheckError:
+            pass
+
         # create user if it doesn't exists
         username = self.get_fqid()
         password = self.data['password']
@@ -62,10 +72,13 @@ class Vdcuser(TemplateBase):
         unauthorize user to all consumed vdc
         """
         self.state.check('actions', 'install', 'ok')
+        
         client = self.ovc
         username = self.get_fqid()
         if client.api.system.usermanager.userexists(name=username):
             client.api.system.usermanager.delete(username=username)
+
+        self.state.delete('actions', 'install')
 
     def groups_set(self, groups):
         """


### PR DESCRIPTION
* Require state **install** to be OK in all actions accept install itself.
* Uninstall action always unsets state **install**.
* In `add_user` for `vdc` and `account` template add check that user was installed.
* Add argument validation in `add_user` actions: `name` should be given. 

closes: #74