### PR TITLE
Clean up 0-templates

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,20 @@
+# Communication with Zero-Robot
+
+Each [Zero-Robot](https://github.com/zero-os/0-robot) exposes a RESTful API.
+API requests allow to create/delete/manage services on the Zero-Robot. Each API call can be addressed to an individual service, as well as contain a blueprint with a list of services to create and list of actions to execute on the Zero-Robot.
+There are several possibilities to send API calls:
+
+* (recommended) directly with applications like Insomnia or Postman.
+* (recommended) using the JumpScale client for Zero-Robot, this requires [JumpScale](https://github.com/Jumpscale) environment (easy to set up and use with Zero-Robot, convenient for automation).
+* (not recommended) using the `zrobot` CLI tool, for sending blueprints and control services.
+
+## Design
+
+Network of Zero-Robots managing G8s depends on the use case and can be chosen.
+We currently assume that you have one Zero-Robot per Partner Portal, responsible for managing all accounts, users, virtual datacenters (VDCs), virtual machines (nodes) and disks linked to that Partner Portal. This Zero-Robot can be deployed by another "master" Zero-Robot responsible monitoring all Zero-Robots, and deploying all partner portals.
+All OpenvCloud objects (users, accounts, VDCs, VMs, and disks) are managed by services of corresponding type. Each service is an instance of a template, specifically designed to be used by a Zero-Robot.
+Creating, deleting services and scheduling  tasks on the services is possible by sending API calls to the Zero-Robot managing an OpenvCloud account.
+All actions for an OpenvCloud object have to be executed via Zero-Robot services, therefore, it is important that all communication (also from the VDC Control Panel) go through the Zero-Robot, and thus not directly to the G8s. This concept is illustrated by the figure below.
+OpenvCloud templates with examples for communication with a Zero-Robot using the JumpScale client for Zero-Robot and the Zero-Robot CLI tool for creating services and managing OpenvCloud objects can be found [here](https://github.com/openvcloud/0-templates). Examples include creating and managing accounts, VDCs, VMs, and disks.
+
+<img src="https://docs.google.com/drawings/d/e/2PACX-1vR7UL8ZphMb8P6fsvmmcT3HOITiu8bRK6lhD1ZTlA-sp5v-yg_sgC_WbC6dhB0r9pj2I_Q0axr8ZUFt/pub?w=713&h=625">

--- a/templates/account/README.md
+++ b/templates/account/README.md
@@ -6,7 +6,7 @@ This template is responsible for creating an account on a openVCloud environment
 
 ## Schema
 
-- `name`: Name of the account on OVC **required**
+- `name`: Name of the account on OVC **Required**.
 - `openvcloud`: Name of the [openvcloud](../openvcloud) instance used to connect to the environment.  **Required**.
 - `description`: Arbitrary description of the account. **Optional**.
 - `maxMemoryCapacity`: The limit on the memory capacity that can be used by the account. Default to -1 (unlimited).
@@ -32,7 +32,7 @@ For information about the different access rights, check docs at [openvcloud](ht
 ## Actions
 
 - `install`: creates an account or gets an existent account.
-- `uninstall`: delete an account. All VDCs (Virtual Data Centers) related to this account will be destroyed and uninstall should not be called on those VDC services when uninstalling an account.
+- `uninstall`: delete an account and trigger uninstall on all VDCs (Virtual Data Centers) linked to this account.
 - `user_authorize`: adds a user to the account or updates access rights. In order to add a user, corresponding [`vdcuser`](#vdc-user) service should be installed.
 - `user_unauthorize`: deletes a user from the account.
 - `update`: updates the account attributes:

--- a/templates/account/account.py
+++ b/templates/account/account.py
@@ -10,6 +10,7 @@ class Account(TemplateBase):
     template_name = "account"
 
     OVC_TEMPLATE = 'github.com/openvcloud/0-templates/openvcloud/0.0.1'
+    VDC_TEMPLATE = 'github.com/openvcloud/0-templates/vdc/0.0.1'
     VDCUSER_TEMPLATE = 'github.com/openvcloud/0-templates/vdcuser/0.0.1'
 
     def __init__(self, name, guid=None, data=None):
@@ -132,8 +133,17 @@ class Account(TemplateBase):
         if not self.data['create']:
             raise RuntimeError('readonly account')
 
-        acc = self.ovc.account_get(self.data['name'], create=False)
-        acc.delete()
+        if self.data['name'] in [acc.model['name'] for acc in self.ovc.accounts]:
+            acc = self.ovc.account_get(self.data['name'], create=False)
+            acc.delete()
+
+        # unintall vdc services linked to this account
+        vdcs = self.api.services.find(template_uid=self.VDC_TEMPLATE)
+        for vdc in vdcs:
+            task = vdc.schedule_action('get_account')
+            task.wait()
+            if task.result == self.name:
+                vdc.schedule_action('uninstall')
 
         self.state.delete('actions', 'install')
 

--- a/templates/account/test_account.py
+++ b/templates/account/test_account.py
@@ -18,10 +18,6 @@ class TestAccount(TestCase):
             os.path.dirname(__file__)
         )
 
-        # define properties of account mock
-        #acc_mock =  MagicMock(model={'acl': []})
-        # self.ovc_mock = MagicMock(account_get=MagicMock(return_value=acc_mock),
-        #                           accounts={})
         self.ovc = {'service': 'test_ovc_service',
                     'info': {'name': 'connection_instance_name'}
                     }
@@ -35,6 +31,9 @@ class TestAccount(TestCase):
                         'info': {'name': 'test_vdcuser@itsyouonline',
                         'openvcloud': self.ovc['service']}
                         }                    
+
+    def tearDown(self):
+        patch.stopall()
 
     @staticmethod
     def set_up_proxy_mock(result=None, state='ok', name='service_name'):

--- a/templates/account/test_account.py
+++ b/templates/account/test_account.py
@@ -20,7 +20,8 @@ class TestAccount(TestCase):
 
         # define properties of account mock
         acc_mock =  MagicMock(model={'acl': []})
-        self.ovc_mock = MagicMock(account_get=MagicMock(return_value=acc_mock))      
+        self.ovc_mock = MagicMock(account_get=MagicMock(return_value=acc_mock),
+                                  accounts={})      
 
     def test_validate_openvcloud(self):
         data = {
@@ -172,12 +173,22 @@ class TestAccount(TestCase):
             'name': 'test_account',
             }
 
+        # if account doesn't exist on ovc do nothing
         account = ovc.get.return_value.account_get.return_value
         instance = self.type('test', None, data)
         with mock.patch.object(instance, 'api') as api:
             api.services.find.return_value = [MagicMock()]        
             instance.uninstall()
-        account.delete.assert_called_once_with()     
+        account.delete.assert_not_called()
+
+        # successful delete
+        account = ovc.get.return_value.account_get.return_value
+        instance = self.type('test', None, data)
+        with mock.patch.object(instance, 'api') as api:
+            api.services.find.return_value = [MagicMock()]
+            ovc.get.return_value.accounts = [MagicMock(model={'name': data['name']})]
+            instance.uninstall()
+        account.delete.assert_called_once_with()       
 
     @mock.patch.object(j.clients, '_openvcloud')
     def test_uninstall_fail(self, ovc):

--- a/templates/account/test_account.py
+++ b/templates/account/test_account.py
@@ -19,136 +19,122 @@ class TestAccount(TestCase):
         )
 
         # define properties of account mock
-        acc_mock =  MagicMock(model={'acl': []})
-        self.ovc_mock = MagicMock(account_get=MagicMock(return_value=acc_mock),
-                                  accounts={})      
+        #acc_mock =  MagicMock(model={'acl': []})
+        # self.ovc_mock = MagicMock(account_get=MagicMock(return_value=acc_mock),
+        #                           accounts={})
+        self.ovc = {'service': 'test_ovc_service',
+                    'info': {'name': 'connection_instance_name'}
+                    }
+        self.acc = {'service': 'test_account_service',
+                    'info': {'name': 'test_account',
+                             'openvcloud': self.ovc['service']}
+                    }
+        self.vdcuser = {'service': 'test_vdcuser_service',
+                        'base_name': 'test_vdcuser',
+                        'accesstype': 'R',
+                        'info': {'name': 'test_vdcuser@itsyouonline',
+                        'openvcloud': self.ovc['service']}
+                        }                    
 
-    def test_validate_openvcloud(self):
-        data = {
-            'openvcloud': 'connection',
-            'name': 'test_account',
-        }
+    @staticmethod
+    def set_up_proxy_mock(result=None, state='ok', name='service_name'):
+        task = MagicMock(result=result, state=state)
+        proxy = MagicMock(schedule_action=MagicMock(return_value=task))
+        proxy.name = name
+        return proxy
+
+    def find(self, template_uid, name):
+        if template_uid == self.type.OVC_TEMPLATE:
+            self.assertEqual(name, self.ovc['service'])
+            proxy = self.set_up_proxy_mock(result=self.ovc['info'])
+        if template_uid == self.type.VDCUSER_TEMPLATE:
+            proxy = self.set_up_proxy_mock(result=self.vdcuser['info'])        
+        return [proxy]
+
+    def ovc_mock(self, instance):
+        acc_mock = MagicMock(model={'acl': [{'userGroupId': self.vdcuser['info']['name'],
+                                             'right': self.vdcuser['accesstype']}],
+                                    'id': 111, 'name': self.acc['info']['name']},
+                                    )
+        ovc = MagicMock(account_get=MagicMock(return_value=acc_mock))
+        ovc.accounts = [acc_mock]
+        return ovc
+
+    def test_validate_success(self):
+        data = self.acc['info']
         name = 'test'
         instance = self.type(name, None, data)
+        instance.validate()
 
-        def find(template_uid, name):
-            self.assertEqual(template_uid, self.type.OVC_TEMPLATE)
-            self.assertEqual(name, data['openvcloud'])
-
-            result = mock.MagicMock()
-            result.name = name
-            return [result]
-
-        with mock.patch.object(instance, 'api') as api:
-            api.services.find.side_effect = find
-            instance.validate()
-
-        api.services.find.assert_called_once_with(template_uid=self.type.OVC_TEMPLATE, name=data['openvcloud'])
-
-        # Next, we test when NO connection is given
-        api.reset_mock()
-
-    def test_validate_openvcloud_fail_no_connection(self):
+    def test_validate_fail_missing_name(self):
         data = {}
         name = 'test'
         instance = self.type(name, None, data)
-
-        def find(template_uid, name):
-            self.assertEqual(template_uid, self.type.OVC_TEMPLATE)
-            self.assertEqual(name, None)
-
-            result = mock.MagicMock()
-            result.name = name
-            return [result]
-
-        with mock.patch.object(instance, 'api') as api:
-            api.services.find.side_effect = find
-            with self.assertRaises(ValueError):
-                instance.validate()
-
-            api.services.find.assert_not_called()
-
-    def test_validate_openvcloud_fail_find_more_than_one_object(self):
-        # Finally, if the search returned more than one object
-        name = 'test'
-        data = {
-            'openvcloud': 'connection',
-            'name': 'test_account',
-        }
-        instance = self.type(name, None, data)
-
-        def find(template_uid, name):
-            self.assertEqual(template_uid, self.type.OVC_TEMPLATE)
-            self.assertEqual(name, data['openvcloud'])
-
-            result = mock.MagicMock()
-            result.name = name
-            return [result, result]  # return 2
-
-        with mock.patch.object(instance, 'api') as api:
-            api.services.find.side_effect = find
-            with self.assertRaises(RuntimeError):
-                instance.validate()
-
-        api.services.find.assert_called_once_with(template_uid=self.type.OVC_TEMPLATE, name=data['openvcloud'])
-
-    def test_validate(self):
-        """
-        Test validate method
-        """
-        data = {
-            'openvcloud': 'connection',
-            'name': 'test_account',
-        }
-        name = 'test'
-        instance = self.type(name, None, data)
-
-        def find(template_uid, name):
-            if template_uid == self.type.OVC_TEMPLATE:
-                # handle the connection search (tested in another test method)
-                result = mock.MagicMock()
-                result.name = 'connection'
-                return [result]
-
-            self.assertEqual(template_uid, self.type.VDCUSER_TEMPLATE)
-
-            result = mock.MagicMock()
-            result.name = name
-            return [result]
-
-        with mock.patch.object(instance, 'api') as api:
-            api.services.find.side_effect = find
+        
+        with self.assertRaisesRegex(ValueError,
+                                     '"name" is required'):
             instance.validate()
 
-        api.services.find.assert_has_calls(
-            [mock.call(template_uid=self.type.OVC_TEMPLATE, name=data['openvcloud'])]
-        )
-
-    @mock.patch.object(j.clients, '_openvcloud')
-    def test_install(self, openvcloud):
-        data = {
-            'openvcloud': 'connection',
-            'name': 'test_account',
-        }
-        connection_name = 'be-gen'
+    def test_validate_fail_missing_ovc(self):
+        data = {'name': 'account_name'}
         name = 'test'
         instance = self.type(name, None, data)
+        
+        with self.assertRaisesRegex(ValueError,
+                                     '"openvcloud" is required'):
+            instance.validate()
+    
+    @mock.patch.object(j.clients, '_openvcloud')
+    def test_ovc_success(self, ovc):
+        """ Test ovc client getter """
+        data = self.acc['info']
+        instance = self.type('test', None, data)
+        ovc.get.return_value = self.ovc_mock(self.ovc['info']['name'])
+        with patch.object(instance, 'api') as api:
+            api.services.find.side_effect = self.find
+            instance.ovc
 
-        # mock finding services
-        def find(template_uid, name): 
-            self.assertEqual(template_uid, self.type.OVC_TEMPLATE)
-            self.assertEqual(name, data['openvcloud'])    
-            task_mock = MagicMock(result=connection_name)
-            proxy = MagicMock(schedule_action=MagicMock(return_value=task_mock))
-            return [proxy]
+    @mock.patch.object(j.clients, '_openvcloud')
+    def test_ovc_fail_missing_ovc_service(self, ovc):
+        """ Test ovc client getter """
+        data = self.acc['info']
+        instance = self.type('test', None, data)
+        ovc.get.return_value = self.ovc_mock(self.ovc['info']['name'])
+        with patch.object(instance, 'api') as api:
+            api.services.find.return_value = []
+            with self.assertRaisesRegex(RuntimeError,
+                                        'found 0 services with name "%s", required exactly one' %
+                                        self.ovc['service']):
+                instance.ovc
 
+    @mock.patch.object(j.clients, '_openvcloud')
+    def test_ovc_fail_get_info(self, ovc):
+        """ Test ovc client getter """
+        data = self.acc['info']
+        instance = self.type('test', None, data)
+        ovc.get.return_value = self.ovc_mock(self.ovc['info']['name'])
+        with patch.object(instance, 'api') as api:
+            api.services.find.return_value = [
+                self.set_up_proxy_mock(state='error', name=self.ovc['service'])
+                ]
+            with self.assertRaisesRegex(RuntimeError,
+                                        'error occurred when executing action "get_info" on service "%s"' %
+                                        self.ovc['service']):
+                instance.ovc
+
+    @mock.patch.object(j.clients, '_openvcloud')
+    def test_install(self, ovc):
+        data = self.acc['info']
+        instance = self.type('test', None, data)
+
+        ovc.get.return_value = self.ovc_mock(self.ovc['info']['name'])
         with mock.patch.object(instance, 'api') as api:
-            api.services.find.side_effect = find
+            api.services.find.side_effect = self.find
             instance.install()
 
-        openvcloud.get.assert_called_once_with(connection_name)
+        ovc.get.assert_called_once_with(self.ovc['info']['name'])
 
-        cl = openvcloud.get.return_value
+        cl = ovc.get.return_value
         cl.account_get.assert_called_once_with(
             name=data['name'],
             create=True,
@@ -163,71 +149,108 @@ class TestAccount(TestCase):
         account.save.assert_called_once_with()
 
     @mock.patch.object(j.clients, '_openvcloud')
+    def test_uninstall_nonexistent_account(self, ovc):
+        """
+        Test uninstall account
+        """
+        data = self.acc['info']
+        instance = self.type('test', None, data)
+
+        # if account doesn't exist on ovc do nothing
+        ovc.get.return_value = self.ovc_mock(self.ovc['info']['name'])
+        client = ovc.get.return_value
+        client.accounts = []
+
+        with mock.patch.object(instance, 'api') as api:
+            api.services.find.side_effect = self.find
+            instance.uninstall()
+
+        account = client.account_get.return_value
+        account.delete.assert_not_called()
+
+    @mock.patch.object(j.clients, '_openvcloud')
     def test_uninstall_success(self, ovc):
         """
         Test uninstall account
         """
-
-        data = {
-            'openvcloud': 'connection',
-            'name': 'test_account',
-            }
+        data = self.acc['info']
+        instance = self.type('test', None, data)
 
         # if account doesn't exist on ovc do nothing
-        account = ovc.get.return_value.account_get.return_value
-        instance = self.type('test', None, data)
+        ovc.get.return_value = self.ovc_mock(self.ovc['info']['name'])
+        client = ovc.get.return_value
+        account = client.account_get.return_value
+        account.spaces = []
+        
         with mock.patch.object(instance, 'api') as api:
-            api.services.find.return_value = [MagicMock()]        
-            instance.uninstall()
-        account.delete.assert_not_called()
+            api.services.find.side_effect = self.find
 
-        # successful delete
-        account = ovc.get.return_value.account_get.return_value
-        instance = self.type('test', None, data)
-        with mock.patch.object(instance, 'api') as api:
-            api.services.find.return_value = [MagicMock()]
-            ovc.get.return_value.accounts = [MagicMock(model={'name': data['name']})]
             instance.uninstall()
-        account.delete.assert_called_once_with()       
+        account.delete.assert_called_once_with()
 
     @mock.patch.object(j.clients, '_openvcloud')
-    def test_uninstall_fail(self, ovc):
+    def test_uninstall_fail_not_empty(self, ovc):
         """
         Test uninstall account
         """
-        # test error in read-only cloudspace
-        data_read_only = {
-            'openvcloud': 'connection',
-            'name': 'test_account',
-            'create': False,
-            }
-        instance = self.type('test', None, data_read_only)
+        data = self.acc['info']
+        instance = self.type('test', None, data)
 
-        with pytest.raises(RuntimeError,
-                           message='"%s" is readonly cloudspace' % instance.name):
-            instance.uninstall()
-   
+        # if account doesn't exist on ovc do nothing
+        ovc.get.return_value = self.ovc_mock(self.ovc['info']['name'])
+        client = ovc.get.return_value
+        account = client.account_get.return_value
+        
+        with mock.patch.object(instance, 'api') as api:
+            api.services.find.side_effect = self.find
+            with self.assertRaisesRegex(RuntimeError,
+                                        'not empty account cannot be deleted'):
+                instance.uninstall()
+        account.delete.assert_not_called()
+
+    @mock.patch.object(j.clients, '_openvcloud')
+    def test_uninstall_fail_read_only(self, ovc):
+        """
+        Test uninstall account
+        """
+        data = self.acc['info']
+        data['create'] = False
+        instance = self.type('test', None, data)
+
+        # if account doesn't exist on ovc do nothing
+        ovc.get.return_value = self.ovc_mock(self.ovc['info']['name'])
+        client = ovc.get.return_value
+        account = client.account_get.return_value
+        
+        with mock.patch.object(instance, 'api') as api:
+            api.services.find.side_effect = self.find
+            with self.assertRaisesRegex(RuntimeError,
+                                        'readonly account'):
+                instance.uninstall()
+        account.delete.assert_not_called()
 
     def test_update_statecheckerror(self):
         instance = self.type('test', None, {})
         with self.assertRaises(StateCheckError):
             # fails if account not installed
             instance.update()
-        
 
     @mock.patch.object(j.clients, '_openvcloud')
-    def test_update(self, openvcloud):
+    def test_update(self, ovc):
         """
         Test updating account limits
         """
-        instance = self.type('test', None, {})
+        data = self.acc['info']
+        instance = self.type('test', None, data)
         instance.state.set('actions', 'install', 'ok')
-        cl = openvcloud.get.return_value
+
+        ovc.get.return_value = self.ovc_mock(self.ovc['info']['name'])
+        cl = ovc.get.return_value
         account = cl.account_get.return_value
         account.model = {}
 
         with mock.patch.object(instance, 'api') as api:
-            api.services.find.return_value = [MagicMock()]
+            api.services.find.side_effect = self.find
             instance.update(
                 maxMemoryCapacity=1,
                 maxVDiskCapacity=2,
@@ -243,200 +266,262 @@ class TestAccount(TestCase):
 
     def test_user_authorize_statecheckerror(self):
         instance = self.type('test', None)
-        user = {'vdcuser': 'test1', 'accesstype': 'W', 'user_name': 'user@provider'}
+        user = {'vdcuser': 'test1', 'accesstype': 'W',
+                'user_name': 'user@provider'}
         with pytest.raises(StateCheckError):
             # fails if account not installed
             instance.user_authorize(user['vdcuser'], user['accesstype'])
 
-    def test_user_authorize_success(self):
+    @mock.patch.object(j.clients, '_openvcloud')
+    def test_user_authorize_success(self, ovc):
         """
         Test authorizing a new user
         """
-        instance = self.type('test', None)
+        data = self.acc['info']
+        instance = self.type('test', None, data)
         instance.state.set('actions', 'install', 'ok')
 
         # user to add
-        user = {'vdcuser': 'test1', 'accesstype': 'W', 'user_name': 'user@provider'}
+        user = {'vdcuser': self.vdcuser['service'], 
+                'accesstype': 'W',
+                'user_name': self.vdcuser['info']['name']}
 
-        with pytest.raises(ValueError,
-                           message='no vdcuser service found with name "%s"' % user['vdcuser']):
-            # fails if no vdcuser service is running for this user
+        ovc.get.return_value = self.ovc_mock(self.ovc['info']['name'])
+        client = ovc.get.return_value
+        account = client.account_get.return_value
+        account.model = {'acl': []}
+        with patch.object(instance, 'api') as api:
+            api.services.find.side_effect = self.find
             instance.user_authorize(user['vdcuser'], user['accesstype'])
 
-        # mock finding services
-        def find(template_uid, name):     
-            task_mock = MagicMock(result=user['user_name'])
-            proxy = MagicMock(schedule_action=MagicMock(return_value=task_mock))
-            return [proxy]
-
-        with patch.object(instance, 'api') as api:
-            api.services.find.side_effect = find
-            with patch('js9.j.clients.openvcloud.get', return_value=self.ovc_mock) as ovc:           
-                # test success
-                ovc.return_value.account_get.return_value.authorize_user.return_value=True
-                instance.user_authorize(user['vdcuser'], user['accesstype'])
-
-                instance.account.authorize_user.assert_called_once_with(
-                    username=user['user_name'],
-                    right=user['accesstype'])
-                api.services.find.assert_has_calls(
-                    [mock.call(template_uid=self.type.VDCUSER_TEMPLATE, name=user['vdcuser'])]
-                )
-                self.assertEqual(
-                    instance.data['users'],
-                    [
-                        {'name': user['user_name'],
+            instance.account.authorize_user.assert_called_once_with(
+                username=user['user_name'],
+                right=user['accesstype'])
+            api.services.find.assert_has_calls(
+                [mock.call(template_uid=self.type.VDCUSER_TEMPLATE,
+                            name=user['vdcuser'])]
+            )
+            self.assertEqual(
+                instance.data['users'],
+                [
+                    {'name': user['user_name'],
                         'accesstype': user['accesstype']}
-                    ])
-                ovc.return_value.account_get.return_value.authorize_user.return_value=False
-                # user = {'vdcuser': 'test2', 'accesstype': 'R'}
-                with pytest.raises(RuntimeError,
-                                message='failed to add user "%s"' % user['user_name']):
-                    instance.user_authorize(user['vdcuser'], user['accesstype'])
+                ])
 
-    def test_user_authorize_fail(self):
+    @mock.patch.object(j.clients, '_openvcloud')
+    def test_user_authorize_fail(self, ovc):
         """
         Test authorizing a new user
         """
-        instance = self.type('test', None)
+        data = self.acc['info']
+        instance = self.type('test', None, data)
+        instance.state.set('actions', 'install', 'ok')
+        # user to add
+        user = {'vdcuser': self.vdcuser['service'], 
+                'accesstype': 'W',
+                'user_name': self.vdcuser['base_name']}
+
+        ovc.get.return_value = self.ovc_mock(self.ovc['info']['name'])
+        client = ovc.get.return_value
+        account = client.account_get.return_value
+        account.model = {'acl': []}
+        account.authorize_user.return_value = False
+        with patch.object(instance, 'api') as api:
+            api.services.find.side_effect = self.find
+            with self.assertRaisesRegex(RuntimeError, 
+                                        'failed to add user "%s"' %
+                                        self.vdcuser['info']['name']):
+                instance.user_authorize(user['vdcuser'], user['accesstype'])
+
+    @mock.patch.object(j.clients, '_openvcloud')
+    def test_user_update_access_right_success(self, ovc):
+        """
+        Test authorizing a new user
+        """
+        data = self.acc['info']
+        instance = self.type('test', None, data)
+        instance.state.set('actions', 'install', 'ok')
 
         # user to add
-        user = {'vdcuser': 'test1', 'accesstype': 'W', 'user_name': 'user@provider'}
+        user = {'vdcuser': self.vdcuser['service'], 
+                'accesstype': 'W',
+                'user_name': self.vdcuser['info']['name']}
 
-        instance.state.set('actions', 'install', 'ok')
-        with pytest.raises(ValueError,
-                           message='no vdcuser service found with name "%s"' % user['vdcuser']):
-            # fails if no vdcuser service is running for this user
+        ovc.get.return_value = self.ovc_mock(self.ovc['info']['name'])
+        with patch.object(instance, 'api') as api:
+            api.services.find.side_effect = self.find
             instance.user_authorize(user['vdcuser'], user['accesstype'])
 
-        # mock finding services
-        def find(template_uid, name):     
-            task_mock = MagicMock(result=user['user_name'])
-            proxy = MagicMock(schedule_action=MagicMock(return_value=task_mock))
-            return [proxy]
+            instance.account.update_access.assert_called_once_with(
+                username=user['user_name'],
+                right=user['accesstype'])
+            api.services.find.assert_has_calls(
+                [mock.call(template_uid=self.type.VDCUSER_TEMPLATE,
+                            name=user['vdcuser'])]
+            )
+            self.assertEqual(
+                instance.data['users'],
+                [
+                    {'name': user['user_name'],
+                        'accesstype': user['accesstype']}
+                ])
 
+    @mock.patch.object(j.clients, '_openvcloud')
+    def test_user_update_access_right_fail(self, ovc):
+        """
+        Test authorizing a new user
+        """
+        data = self.acc['info']
+        instance = self.type('test', None, data)
+        instance.state.set('actions', 'install', 'ok')
+
+        # user to add
+        user = {'vdcuser': self.vdcuser['service'], 
+                'accesstype': 'W',
+                'user_name': self.vdcuser['info']['name']}
+
+        ovc.get.return_value = self.ovc_mock(self.ovc['info']['name'])
+        client = ovc.get.return_value
+        account = client.account_get.return_value
+        account.authorize_user.return_value = False   
         with patch.object(instance, 'api') as api:
-            api.services.find.side_effect = find
-            with patch('js9.j.clients.openvcloud.get', return_value=self.ovc_mock) as ovc:           
-                # test success
-                ovc.return_value.account_get.return_value.authorize_user.return_value=False
-                with pytest.raises(RuntimeError,
-                                message='failed to add user "%s"' % user['user_name']):
-                    instance.user_authorize(user['vdcuser'], user['accesstype'])
-
-    def test_user_update_access_right_success(self):
-        """
-        Test updating access right of an authorized user
-        """
-        instance = self.type('test', None)
-        # user to update
-        user = {'vdcuser': 'test1', 'accesstype': 'W', 'user_name': 'user@provider'}
-        users = [{'userGroupId': user['user_name'], 'right': 'R'}]
-
-        with pytest.raises(StateCheckError):
-            # fails if account not installed
+            api.services.find.side_effect = self.find
             instance.user_authorize(user['vdcuser'], user['accesstype'])
 
-        instance.state.set('actions', 'install', 'ok')
-
-        # mock finding services
-        def find(template_uid, name):     
-            task_mock = MagicMock(result=user['user_name'])
-            proxy = MagicMock(schedule_action=MagicMock(return_value=task_mock))
-            return [proxy]
-
-        with patch.object(instance, 'api') as api:
-            api.services.find.side_effect = find #[MagicMock(schedule_action=MagicMock())]
-            with patch('js9.j.clients.openvcloud.get', return_value=self.ovc_mock) as ovc:
-                # test success
-                ovc.return_value.account_get.return_value.update_access.return_value=True
-                ovc.return_value.account_get.return_value.model = {'acl': users}
-                instance.user_authorize(user['vdcuser'], user['accesstype'])
-                instance.account.update_access.assert_called_once_with(username=user['user_name'], right=user['accesstype'])
-
-    def test_user_update_access_right_fail(self):
-        """
-        Test updating access right of an authorized user
-        """
-        instance = self.type('test', None)
-        instance.state.set('actions', 'install', 'ok')
-        # user to update
-        user = {'vdcuser': 'test1', 'accesstype': 'W', 'user_name': 'user@provider'}
-        users = [{'userGroupId': user['user_name'], 'right': 'R'}]
-
-        # mock finding services
-        def find(template_uid, name):     
-            task_mock = MagicMock(result=user['user_name'])
-            proxy = MagicMock(schedule_action=MagicMock(return_value=task_mock))
-            return [proxy]
-
-        with patch.object(instance, 'api') as api:
-            api.services.find.side_effect = find #[MagicMock(schedule_action=MagicMock())]
-            with patch('js9.j.clients.openvcloud.get', return_value=self.ovc_mock) as ovc:
-                ovc.return_value.account_get.return_value.update_access.return_value=False
-                ovc.return_value.account_get.return_value.model = {'acl': users}
-                with pytest.raises(RuntimeError,
-                                message='failed to update accesstype of user "test1"'):
-                    instance.user_authorize(user['vdcuser'], user['accesstype'])
+            instance.account.update_access.assert_called_once_with(
+                username=user['user_name'],
+                right=user['accesstype'])
+            api.services.find.assert_has_calls(
+                [mock.call(template_uid=self.type.VDCUSER_TEMPLATE,
+                            name=user['vdcuser'])]
+            )
 
     def test_user_unauthorize_statecheckerror(self):
         instance = self.type('test', None)
-        user = {'vdcuser': 'test1', 'accesstype': 'W', 'user_name': 'user@provider'}       
+        user = {'vdcuser': 'test1', 'accesstype': 'W',
+                'user_name': 'user@provider'}
         with pytest.raises(StateCheckError):
             # fails if account not installed
             instance.user_authorize(user['vdcuser'])
 
-    def test_user_unauthorize_success(self):
+    @mock.patch.object(j.clients, '_openvcloud')
+    def test_user_unauthorize_success(self, ovc):
         """
-        Test deleting a user success
-        """        
-        instance = self.type('test', None)
+        Test authorizing a new user
+        """
+        data = self.acc['info']
+        instance = self.type('test', None, data)
         instance.state.set('actions', 'install', 'ok')
 
-        users = [{'userGroupId': 'user@provider', 'right': 'R'}]
-        # user to delete
-        user = {'vdcuser': 'test1', 'accesstype': 'W', 'user_name': 'user@provider'}
+        # user to add
+        user = {'vdcuser': self.vdcuser['service'], 
+                'accesstype': 'W',
+                'user_name': self.vdcuser['info']['name']}
 
-        # mock finding services
-        def find(template_uid, name):     
-            task_mock = MagicMock(result=user['user_name'])
-            proxy = MagicMock(schedule_action=MagicMock(return_value=task_mock))
-            return [proxy]
-
+        ovc.get.return_value = self.ovc_mock(self.ovc['info']['name'])
         with patch.object(instance, 'api') as api:
-            api.services.find.side_effect = find
-            with patch('js9.j.clients.openvcloud.get', return_value=self.ovc_mock) as ovc:
+            api.services.find.side_effect = self.find
+            instance.user_unauthorize(user['vdcuser'])
 
-                # test success
-                ovc.return_value.account_get.return_value.unauthorize_user.return_value=True
-                ovc.return_value.account_get.return_value.model = {'acl': users}
+            instance.account.unauthorize_user.assert_called_once_with(
+                username=user['user_name'])
+            api.services.find.assert_has_calls(
+                [mock.call(template_uid=self.type.VDCUSER_TEMPLATE,
+                            name=user['vdcuser'])]
+            )
+            self.assertEqual(
+                instance.data['users'], [])
 
-                instance.user_unauthorize(vdcuser=user['vdcuser'])
-                instance.account.unauthorize_user.assert_called_once_with(username=user['user_name'])
-                self.assertEqual(instance.data['users'], [])
-
-    def test_user_unauthorize_fail(self):
+    @mock.patch.object(j.clients, '_openvcloud')
+    def test_user_unauthorize_fail(self, ovc):
         """
-        Test deleting a user fail
-        """        
-        instance = self.type('test', None)
+        Test authorizing a new user
+        """
+        data = self.acc['info']
+        instance = self.type('test', None, data)
         instance.state.set('actions', 'install', 'ok')
 
-        users = [{'userGroupId': 'user@provider', 'right': 'R'}]
-        # user to delete
-        user = {'vdcuser': 'test1', 'accesstype': 'W', 'user_name': 'user@provider'}
+        # user to add
+        user = {'vdcuser': self.vdcuser['service'], 
+                'accesstype': 'W',
+                'user_name': self.vdcuser['info']['name']}
 
-        # mock finding services
-        def find(template_uid, name):     
-            task_mock = MagicMock(result=user['user_name'])
-            proxy = MagicMock(schedule_action=MagicMock(return_value=task_mock))
-            return [proxy]
-
+        ovc.get.return_value = self.ovc_mock(self.ovc['info']['name'])
+        client = ovc.get.return_value
+        account = client.account_get.return_value
+        account.unauthorize_user.return_value = False   
         with patch.object(instance, 'api') as api:
-            api.services.find.side_effect = find
-            with patch('js9.j.clients.openvcloud.get', return_value=self.ovc_mock) as ovc:
-                ovc.return_value.account_get.return_value.unauthorize_user.return_value=False
-                ovc.return_value.account_get.return_value.model = {'acl': users}
-                with pytest.raises(RuntimeError,
-                                   message='failed to remove user "%s"' % user['vdcuser']):
-                    instance.user_unauthorize(vdcuser=user['vdcuser'])
+            api.services.find.side_effect = self.find
+            with self.assertRaisesRegex(RuntimeError,
+                                        'failed to remove user "%s"' % user['user_name']):
+                instance.user_unauthorize(user['vdcuser'])
+
+            instance.account.unauthorize_user.assert_called_once_with(
+                username=user['user_name'])
+            api.services.find.assert_has_calls(
+                [mock.call(template_uid=self.type.VDCUSER_TEMPLATE,
+                            name=user['vdcuser'])]
+            )
+
+
+    # def test_user_unauthorize_success(self):
+    #     """
+    #     Test deleting a user success
+    #     """
+    #     instance = self.type('test', None)
+    #     instance.state.set('actions', 'install', 'ok')
+
+    #     users = [{'userGroupId': 'user@provider', 'right': 'R'}]
+    #     # user to delete
+    #     user = {'vdcuser': 'test1', 'accesstype': 'W',
+    #             'user_name': 'user@provider'}
+
+    #     # mock finding services
+    #     def find(template_uid, name):
+    #         task_mock = MagicMock(result=user['user_name'])
+    #         proxy = MagicMock(
+    #             schedule_action=MagicMock(return_value=task_mock))
+    #         return [proxy]
+
+    #     with patch.object(instance, 'api') as api:
+    #         api.services.find.side_effect = find
+    #         with patch('js9.j.clients.openvcloud.get', return_value=self.ovc_mock) as ovc:
+
+    #             # test success
+    #             ovc.return_value.account_get.return_value.unauthorize_user.return_value = True
+    #             ovc.return_value.account_get.return_value.model = {
+    #                 'acl': users}
+
+    #             instance.user_unauthorize(vdcuser=user['vdcuser'])
+    #             instance.account.unauthorize_user.assert_called_once_with(
+    #                 username=user['user_name'])
+    #             self.assertEqual(instance.data['users'], [])
+
+    # def test_user_unauthorize_fail(self):
+    #     """
+    #     Test deleting a user fail
+    #     """
+    #     instance = self.type('test', None)
+    #     instance.state.set('actions', 'install', 'ok')
+
+    #     users = [{'userGroupId': 'user@provider', 'right': 'R'}]
+    #     # user to delete
+    #     user = {'vdcuser': 'test1', 'accesstype': 'W',
+    #             'user_name': 'user@provider'}
+
+    #     # mock finding services
+    #     def find(template_uid, name):
+    #         task_mock = MagicMock(result=user['user_name'])
+    #         proxy = MagicMock(
+    #             schedule_action=MagicMock(return_value=task_mock))
+    #         return [proxy]
+
+    #     with patch.object(instance, 'api') as api:
+    #         api.services.find.side_effect = find
+    #         with patch('js9.j.clients.openvcloud.get', return_value=self.ovc_mock) as ovc:
+    #             ovc.return_value.account_get.return_value.unauthorize_user.return_value = False
+    #             ovc.return_value.account_get.return_value.model = {
+    #                 'acl': users}
+    #             with pytest.raises(RuntimeError,
+    #                                message='failed to remove user "%s"' % user['vdcuser']):
+    #                 instance.user_unauthorize(vdcuser=user['vdcuser'])

--- a/templates/disk/disk.py
+++ b/templates/disk/disk.py
@@ -8,12 +8,13 @@ class Disk(TemplateBase):
     template_name = "disk"
 
     OVC_TEMPLATE = 'github.com/openvcloud/0-templates/openvcloud/0.0.1'
-    VDC_TEMPLATE = 'github.com/openvcloud/0-templates/vdc/0.0.1'
     ACCOUNT_TEMPLATE = 'github.com/openvcloud/0-templates/account/0.0.1'
+    VDC_TEMPLATE = 'github.com/openvcloud/0-templates/vdc/0.0.1'
 
     def __init__(self, name, guid=None, data=None):
         super().__init__(name=name, guid=guid, data=data)
 
+        self._ovc = None
         self._account = None
         self._config = None
         self._space = None
@@ -32,6 +33,7 @@ class Disk(TemplateBase):
         # ensure that disk has a valid type
         if self.data['type'].upper() not in ["D", "B"]:
             raise ValueError("disk type must be data D or boot B only")
+
         self._validate_limits()
 
     def _validate_limits(self):
@@ -84,21 +86,10 @@ class Disk(TemplateBase):
 
         if any(updated):
             # check that new limits are valid
-            if not self._attached:
-                raise RuntimeError('limiting IO is not supported for detached disks')  
             self._validate_limits()
 
             # apply new limits
             self._limit_io()
-
-    def _attached(self):
-        """ Check if disk id attached """
-        disks = self.account.disks
-        machine_id = [disk['machineID'] for disk in disks if disk['id'] == self.data['diskId']]
-        if machine_id:
-            return True
-
-        return False      
 
     def _update_value(self, arg, value):
         if value is not None:
@@ -130,27 +121,27 @@ class Disk(TemplateBase):
         if self.data['diskId']:
             # if disk is given in data, check if disk exist
             disks = self.account.disks
-            if self.data['diskId'] not in [disk['id'] for disk in disks]:
+            disk = [disk for disk in disks if disk['id'] == self.data['diskId']]
+            if not disk:
                 raise ValueError('Disk with id {} does not exist on account "{}"'.format(
                                   self.data['diskId'], self.account.model['name'])
                                   )
-            if self._attached:
-                # limiting IO is possible only for attached disks
-                self._limit_io()
+            self.data['name'] = disk[0]['name']
+
         else:
             self._create()
 
         self.state.set('actions', 'install', 'ok')
 
     def _create(self):
-        """ Create disk  """
+        """ Create disk in isolation
+        """
         data = self.data
         # check existence of the disk. If ID field was updated in the service
         gid = [location['gid'] for location in self.ovc.locations if location['name'] == data['location']]
         if not gid:
             raise RuntimeError('location "%s" not found' % data['location'])
         
-        # if doesn't exist - create
         data['diskId'] = self.account.disk_create(
                             name=data['name'],
                             gid=gid,
@@ -158,23 +149,22 @@ class Disk(TemplateBase):
                             size=data['size'],
                             type=data['type'],
                         )
-        self._limit_io()
         
     def uninstall(self):
         """
         Uninstall disk. Delete disk if exists.
+
+        :param machine_service: name of the service, 
+                                managing VM where the disk attached.
+                                Relevant only for attached disks
         """
-
-        if self.data['type'] == 'B':
-            raise RuntimeError("can't delete boot disk")
-
-        disks = [disk['id'] for disk in self.account.disks]
-
+        disks = [disk['id'] for disk in self.account.disks]   
+        import ipdb; ipdb.set_trace()
         if self.data['diskId'] in disks:
-            self.account.disk_delete(self.data['diskId'])
-
+            self.account.disk_delete(self.data['diskId'], detach=False)
+        
         self.state.delete('actions', 'install')
-
+        self.data['diskId'] = 0
 
     @property
     def config(self):
@@ -189,24 +179,17 @@ class Disk(TemplateBase):
         # traverse the tree up words so we have all info we need to return, connection and
         # account
 
+        # get real vdc name
         vdc_proxy = self._get_proxy(self.VDC_TEMPLATE, self.data['vdc'])
-        task = vdc_proxy.schedule_action('get_name')
-        task.wait()
-        config['vdc'] = task.result
+        vdc_info = self._execute_task(proxy=vdc_proxy, action='get_info')
+        config['vdc'] = vdc_info['name']
+        account_service_name = vdc_info['account']
 
-        task = vdc_proxy.schedule_action('get_account')
-        task.wait()
-        account_service_name = task.result
-
+        # get account name
         account_proxy = self._get_proxy(self.ACCOUNT_TEMPLATE, account_service_name)
-        task = account_proxy.schedule_action('get_name')
-        task.wait()
-        config['account'] = task.result
-
-        # get connection
-        task = account_proxy.schedule_action('get_openvcloud')
-        task.wait()
-        config['ovc'] = task.result
+        account_info = self._execute_task(proxy=account_proxy, action='get_info')
+        config['account'] = account_info['name']
+        config['ovc'] = account_info['openvcloud']
 
         self._config = config
         return self._config
@@ -221,17 +204,21 @@ class Disk(TemplateBase):
             raise RuntimeError('found %d services with name "%s", required exactly one' % (len(matches), service_name))
         return matches[0]
 
-    def get_space(self):
-        '''
-        Return vdc service name where disk belongs to
-        '''
-        return self.data['vdc']
+    def _execute_task(self, proxy, action, args={}):
+        task = proxy.schedule_action(action=action, args=args)
+        task.wait()
+        if task.state is not 'ok':
+            raise RuntimeError(
+                    'error occurred when executing action "%s" on service "%s"' %
+                    (action, proxy.name))
+        return task.result
 
     @property
     def ovc(self):
         """ An ovc connection instance """
-        
-        return j.clients.openvcloud.get(instance=self.config['ovc'])
+        if not self._ovc:
+            self._ovc = j.clients.openvcloud.get(instance=self.config['ovc'])
+        return self._ovc
 
     @property
     def space(self):
@@ -265,14 +252,14 @@ class Disk(TemplateBase):
             write_iops_sec_max=data['writeIopsSecMax'], size_iops_sec=data['sizeIopsSec']
         )
 
-    def get_id(self):
-        """ Return id of the disk """
-
+    def get_info(self):
+        """ Retrun disk info if disk is installed """
         self.state.check('actions', 'install', 'ok')
-        return self.data['diskId']
 
-    def get_type(self):
-        """ Return type of the disk """
-        
-        self.state.check('actions', 'install', 'ok')
-        return self.data['type']        
+        return {
+            'serviceName' : self.name,
+            'deviceName' : self.data['name'],
+            'diskId' : self.data['diskId'],
+            'diskType' : self.data['type'],
+            'vdc' : self.data['vdc'],
+        }

--- a/templates/disk/disk.py
+++ b/templates/disk/disk.py
@@ -221,6 +221,12 @@ class Disk(TemplateBase):
             raise RuntimeError('found %d services with name "%s", required exactly one' % (len(matches), service_name))
         return matches[0]
 
+    def get_space(self):
+        '''
+        Return vdc service name where disk belongs to
+        '''
+        return self.data['vdc']
+
     @property
     def ovc(self):
         """ An ovc connection instance """

--- a/templates/disk/schema.capnp
+++ b/templates/disk/schema.capnp
@@ -15,7 +15,7 @@ struct Schema {
 	# id of the disk 
 	diskId @4: Int64;
 
-	# Virtual Data Center id
+	# Virtual Data Center service name
 	vdc @5 :Text;
 
 	# location of the disk

--- a/templates/disk/test_disk.py
+++ b/templates/disk/test_disk.py
@@ -21,19 +21,40 @@ class TestDisk(TestCase):
         self.location_gid = 123
         self.account_name = 'test_account'
         # define properties of space mock
-        account_mock = MagicMock(disks=[{'id':self.disk_id}],
-                                 disk_create=MagicMock(return_value=self.disk_id),
-                                 model={'name': self.account_name})
-        space_mock = MagicMock(model={'acl': [], 'location':self.location},
-                               account=account_mock)
-        self.ovc_mock = MagicMock(space_get=MagicMock(return_value=space_mock),
-                                  locations=[
-                                      { 
-                                        'name':self.location,
-                                        'gid': self.location_gid,
-                                      }
-                                    ],
-                                )
+        # account_mock = MagicMock(disks=[{'id':self.disk_id}],
+        #                          disk_create=MagicMock(return_value=self.disk_id),
+        #                          model={'name': self.account_name})
+        # space_mock = MagicMock(model={'acl': [], 'location':self.location},
+        #                        account=account_mock)
+        # self.ovc_mock = MagicMock(space_get=MagicMock(return_value=space_mock),
+        #                           locations=[
+        #                               { 
+        #                                 'name':self.location,
+        #                                 'gid': self.location_gid,
+        #                               }
+        #                             ],
+        #                         )
+        self.acc = {'service': 'test_account_service',
+                    'info': {'name': 'test_account_real_name',
+                             'openvcloud': 'be-gen'}
+                    }
+        self.vdc = {'service': 'test_vdc_service',
+                    'info': {'name': 'test_vdc_real_name',
+                             'account': self.acc['service']}
+                    }
+        self.disk = {'service': 'test_disk_service',
+                     'info': {'name': 'disk_real_name',
+                              'vdc': self.vdc['service'],
+                              'diskId': 1,
+                              'diskType': 'D',
+                        },
+                }
+
+    def tearDown(self):
+        patch.stopall()
+
+
+
 
     def test_validate_success_name(self):
         """
@@ -492,8 +513,3 @@ class TestDisk(TestCase):
             ovc.get.return_value = self.ovc_mock
 
             instance.update(maxIops=maxIops)
-
-        # instance.ovc.api.cloudapi.disks.limitIO.assert_called_once_with(
-        #     diskId=data['diskId'], 
-        #     iops=maxIops
-        # )

--- a/templates/node/README.md
+++ b/templates/node/README.md
@@ -27,7 +27,7 @@ The template is responsible for managing a virtual machine (VM) on the OpenvClou
 
 ## Actions
 
-- `install`: install VM. If state of action `install` is not `ok`, a new VM will be created. If machine with the same name already exists, if will be deleted and installed again.
+- `install`: install VM. If state of action `install` is not `ok`, and VM with given `name` doesn't exist a new VM will be created. If VM already exists `install` action will try to bring it to desired state, if not possible, throws an error. Desired state: 1 boot disk of size `bootdiskSize`, one data disk of size `dataDiskSize` with filesystem `ext4` mounted on `/var`.
 - `uninstall`: delete VM.
 - `stop`: stop VM.
 - `start`: start VM.

--- a/templates/node/README.md
+++ b/templates/node/README.md
@@ -27,6 +27,8 @@ The template is responsible for managing a virtual machine (VM) on the OpenvClou
 
 ## Actions
 
+### VM actions
+
 - `install`: install VM. If state of action `install` is not `ok`, and VM with given `name` doesn't exist a new VM will be created. If VM already exists `install` action will try to bring it to desired state, if not possible, throws an error. Desired state: 1 boot disk of size `bootdiskSize`, one data disk of size `dataDiskSize` with filesystem `ext4` mounted on `/var`.
 - `uninstall`: delete VM.
 - `stop`: stop VM.
@@ -38,10 +40,16 @@ The template is responsible for managing a virtual machine (VM) on the OpenvClou
 - `snapshot`: create a snapshot of the VM.
 - `snapshot_delete`: delete a snapshot of the VM.
 - `list_snapshots`: return a list of snapshots of the VM.
-- `disk_add`: create a new disk on the VM.
+- `disk_add`: create a new disk on the VM. A service of type `github.com/openvcloud/0-templates/disk/0.0.1` will be created to manage the disk. Name of the disk service is generated automatically in from `Disk{DiskId}`, for example `Disk1234`.
 - `disk_attach`: attach disk to the VM.
 - `disk_detach`: detach disk from the VM.
 - `disk_delete`: delete disk, attached to the VM.
+
+### Actions to fetch VM info
+
+- `get_name`: return VM name.
+- `get_id`: return VM id.
+- `get_disk_services`: return list of the services managing disks attached to the vm.
 
 ## Usage examples via the 0-robot DSL
 
@@ -98,6 +106,9 @@ node.schedule_action('restart')
 node.schedule_action('clone')
 node.schedule_action('snapshot')
 node.schedule_action('snapshot_delete', {'snapshot_epoch': 1522839792})
+
+# required arg to create a new disk at the VM:
+#   @name: device name of the disk object
 node.schedule_action('disk_add', {'name': 'testDisk', 'size': 10})
 node.schedule_action('disk_attach', {'disk_service_name': 'Disk0000'})
 node.schedule_action('disk_detach', {'disk_service_name': 'Disk0000'})

--- a/templates/node/node.py
+++ b/templates/node/node.py
@@ -49,6 +49,19 @@ class Node(TemplateBase):
 
         self.state.check('actions', 'install', 'ok') 
         return self.data['machineId']
+        
+    def get_disk_services(self):
+        '''
+        Return service names of the disks attached to the VM
+        '''        
+        
+        return self.data['disks']
+
+    def get_space(self):
+        '''
+        Return vdc service name
+        '''           
+        return self.data['vdc']
 
     def _get_proxy(self, template_uid, service_name):
         """
@@ -283,9 +296,6 @@ class Node(TemplateBase):
         # append service name to the list of attached disks
         self.data['disks'].append(service_name)
 
-    def get_disk_services(self):
-        return self.data['disks']
-
     def _get_prefab(self):
         """ Get prefab """
 
@@ -301,6 +311,11 @@ class Node(TemplateBase):
 
         if self.machine:
             self.machine.delete()
+
+        # uninstall services for disks attached to the vm
+        for disk in self.data['disks']:
+            proxy = self._get_proxy(self.DISK_TEMPLATE, disk)
+            proxy.schedule_action('uninstall')
 
         self._machine = None
 

--- a/templates/node/node.py
+++ b/templates/node/node.py
@@ -2,6 +2,7 @@ import re
 from js9 import j
 from zerorobot.template.base import TemplateBase
 from zerorobot.template.state import StateCheckError
+from zerorobot.template.decorator import retry
 
 
 class Node(TemplateBase):
@@ -140,6 +141,8 @@ class Node(TemplateBase):
 
         return self._machine
 
+    @retry((BaseException),
+            tries=5, delay=3, backoff=2, logger=None)
     def install(self):
         """ Install VM """
 

--- a/templates/openvcloud/openvcloud.py
+++ b/templates/openvcloud/openvcloud.py
@@ -16,13 +16,17 @@ class Openvcloud(TemplateBase):
             if not self.data[key]:
                 raise ValueError('%s is required' % key)
 
-    def get_name(self):
-        '''
-        Return name of ovc connection if successfully installed
-        '''
+    def get_info(self):
+        """
+        Return info of ovc connection if successfully installed
+        """
 
         self.state.check('actions', 'install', 'ok')
-        return self.data['name']
+        return {
+            'name' : self.data['name'],
+            'location' : self.data['location'],
+            'address' : self.data['address'],
+        }
 
     def _configure(self):
         ovc = j.clients.openvcloud.get(
@@ -39,11 +43,10 @@ class Openvcloud(TemplateBase):
         # save config
         ovc.config.save()
 
-
     def install(self):
-        '''
+        """
         Configure ovc connection
-        '''
+        """
         try:
             self.state.check('actions', 'install', 'ok')
             return
@@ -54,18 +57,18 @@ class Openvcloud(TemplateBase):
         self.state.set('actions', 'install', 'ok')
 
     def uninstall(self):
-        '''
+        """
         Delete ovc connection from config manager on zrobot machine
-        '''
+        """
 
         conf_manager = j.tools.configmanager
         conf_manager.delete(location="j.clients.openvcloud", instance=self.data['name'])
         self.state.delete('actions', 'install')
 
     def update(self, address=None, token=None, port=None):
-        '''
+        """
         Update data and reconfigure ovc connection
-        '''
+        """
         self.state.check('actions', 'install', 'ok')
         kwargs = locals()
 

--- a/templates/openvcloud/test_openvcloud.py
+++ b/templates/openvcloud/test_openvcloud.py
@@ -17,6 +17,9 @@ class TestOpenvcloud(TestCase):
             os.path.dirname(__file__)
         )
 
+    def tearDown(self):
+        mock.patch.stopall()
+
     def test_validate(self):
         # test fail if name is not given
         name = 'test'

--- a/templates/sshkey/sshkey.py
+++ b/templates/sshkey/sshkey.py
@@ -14,10 +14,10 @@ class Sshkey(TemplateBase):
 
     
     def validate(self):
-        '''
+        """
         Implements 0-Robot validate
         Validates the sshkey service
-        '''
+        """
 
         # validate sshkey name
         if not self.data['name']:
@@ -31,9 +31,9 @@ class Sshkey(TemplateBase):
             raise ValueError('passphrase must be min of 5 characters')
 
     def install(self):
-        '''
+        """
         Installs the ssh key
-        '''
+        """
         try:
             self.state.check('actions', 'install', 'ok')
             return
@@ -46,7 +46,8 @@ class Sshkey(TemplateBase):
 
         path = j.sal.fs.joinPaths(dir, name)
         if not j.sal.fs.exists(path):
-            j.clients.sshkey.key_generate(path, passphrase=passphrase, overwrite=True, returnObj=False)
+            j.clients.sshkey.key_generate(
+                path, passphrase=passphrase, overwrite=True, returnObj=False)
         else:
             paramiko.RSAKey.from_private_key_file(path, password=passphrase)
 
@@ -55,10 +56,10 @@ class Sshkey(TemplateBase):
         self.state.set('actions', 'install', 'ok')
 
     def uninstall(self):
-        '''
+        """
         Uninstalls the sshkey client
         Also deletes the key
-        '''
+        """
         key = self._get_key()
         key.delete()
 
@@ -78,9 +79,12 @@ class Sshkey(TemplateBase):
             },
         )
 
-    def get_name(self):
-        '''
-        Return key name
-        '''
+    def get_info(self):
+        """
+        Return sshkey info
+        """
         self.state.check('actions', 'install', 'ok')
-        return self.data['name']
+        return {
+            'name' : self.data['name'],
+            'dir' : self.data['dir'],
+        }

--- a/templates/sshkey/test_sshkey.py
+++ b/templates/sshkey/test_sshkey.py
@@ -15,6 +15,9 @@ class TestSshKey(TestCase):
             os.path.dirname(__file__)
         )
 
+    def tearDown(self):
+        mock.patch.stopall()
+
     @mock.patch.object(j.clients, '_sshkey')
     def test_create(self, ssh):
         dir = '/tmp'

--- a/templates/vdc/README.md
+++ b/templates/vdc/README.md
@@ -27,7 +27,7 @@ For information about the different access rights check docs at [openvcloud](htt
 ## Actions
 
 - `install`: create a VDC in given `account` if doesn't exist.
-- `uninstall`: delete a VDC.
+- `uninstall`: delete a VDC and trigger `uninstall` action on VMs and Disks created on this VDC.
 - `enable`: enable VDC.
 - `disable`: disable VDC.
 - `portforward_create`: create a port forward.

--- a/templates/vdc/test_vdc.py
+++ b/templates/vdc/test_vdc.py
@@ -151,7 +151,6 @@ class TestVDC(TestCase):
 
         instance = self.type('test', None, data)
 
-
         with patch.object(instance, 'api') as api:
             api.services.find.return_value = []
             with pytest.raises(RuntimeError,

--- a/templates/vdc/vdc.py
+++ b/templates/vdc/vdc.py
@@ -2,7 +2,7 @@ import time
 from js9 import j
 from zerorobot.template.base import TemplateBase
 from zerorobot.template.state import StateCheckError
-
+from zerorobot.template.decorator import retry
 
 class Vdc(TemplateBase):
 
@@ -107,6 +107,8 @@ class Vdc(TemplateBase):
         self.data['users'] = users
         return self.data['users']
 
+    @retry((BaseException),
+            tries=5, delay=3, backoff=2, logger=None)
     def install(self):
         """
         Install vdc. Will be created if doesn't exist
@@ -118,7 +120,6 @@ class Vdc(TemplateBase):
         except StateCheckError:
             pass
 
-        acc = self.account
         if not self.data['create']:
             space = self.space
             self.get_users(refresh=False)
@@ -131,7 +132,8 @@ class Vdc(TemplateBase):
         externalnetworkId = self.data.get('externalNetworkID', -1)
         if externalnetworkId == -1:
             externalnetworkId = None
-        self._space = acc.space_get(
+
+        self._space = self.account.space_get(
             name=self.data['name'],
             create=True,
             maxMemoryCapacity=self.data.get('maxMemoryCapacity', -1),
@@ -386,4 +388,3 @@ class Vdc(TemplateBase):
 
         if updated:
             space.save()
-

--- a/templates/vdc/vdc.py
+++ b/templates/vdc/vdc.py
@@ -9,6 +9,7 @@ class Vdc(TemplateBase):
     version = '0.0.1'
     template_name = "vdc"
 
+    OVC_TEMPLATE = 'github.com/openvcloud/0-templates/openvcloud/0.0.1'
     ACCOUNT_TEMPLATE = 'github.com/openvcloud/0-templates/account/0.0.1'
     VDCUSER_TEMPLATE = 'github.com/openvcloud/0-templates/vdcuser/0.0.1'
     NODE_TEMPLATE = 'github.com/openvcloud/0-templates/node/0.0.1'
@@ -65,9 +66,15 @@ class Vdc(TemplateBase):
         An ovc connection instance
         """
         if not self._ovc:
+            # get name of ovc service
             proxy = self._get_proxy(self.ACCOUNT_TEMPLATE, self.data['account'])
             account_info = self._execute_task(proxy=proxy, action='get_info')
-            self._ovc = j.clients.openvcloud.get(account_info['openvcloud'])
+            ovc_service = account_info['openvcloud']
+
+            # get name of ovc connection instance
+            proxy = self._get_proxy(self.OVC_TEMPLATE, ovc_service)
+            ovc_info = self._execute_task(proxy=proxy, action='get_info')
+            self._ovc = j.clients.openvcloud.get(ovc_info['name'])
 
         return self._ovc
 
@@ -302,7 +309,6 @@ class Vdc(TemplateBase):
             if existent_user['accesstype'] == accesstype:
                 # nothing to do here
                 break
-
             if self.space.update_access(username=name, right=accesstype):
                 existent_user['accesstype'] = accesstype
                 break

--- a/templates/vdc/vdc.py
+++ b/templates/vdc/vdc.py
@@ -41,25 +41,33 @@ class Vdc(TemplateBase):
             raise RuntimeError('found %d services with name "%s", required exactly one' % (len(matches), service_name))
         return matches[0]
 
-    def get_name(self):
-        """ Return vdc name """
+    def _execute_task(self, proxy, action, args={}):
+        task = proxy.schedule_action(action=action)
+        task.wait()
+        if task.state is not 'ok':
+            raise RuntimeError(
+                    'error occurred when executing action "%s" on service "%s"' %
+                    (action, proxy.name))
+        return task.result
+
+    def get_info(self):
+        """ Return vdc info """
         self.state.check('actions', 'install', 'ok')
-        return self.data['name']
+        return {
+            'name' : self.data['name'],
+            'account' : self.data['account'],
+            'users' : self._get_users(),
+        }
 
     @property
     def ovc(self):
         """
         An ovc connection instance
         """
-        if self._ovc is not None:
-            return self._ovc
-
-        proxy = self._get_proxy(self.ACCOUNT_TEMPLATE, self.data['account'])
-        # get connection
-        task = proxy.schedule_action('get_openvcloud')
-        task.wait()
-
-        self._ovc = j.clients.openvcloud.get(task.result)
+        if not self._ovc:
+            proxy = self._get_proxy(self.ACCOUNT_TEMPLATE, self.data['account'])
+            account_info = self._execute_task(proxy=proxy, action='get_info')
+            self._ovc = j.clients.openvcloud.get(account_info['openvcloud'])
 
         return self._ovc
 
@@ -70,21 +78,13 @@ class Vdc(TemplateBase):
         if self._account is not None:
             return self._account
 
-        proxy = self._get_proxy(self.ACCOUNT_TEMPLATE, self.data['account'])
-
         # get actual account name
-        task = proxy.schedule_action('get_name')
-        task.wait()
-        account_name = task.result
+        proxy = self._get_proxy(self.ACCOUNT_TEMPLATE, self.data['account'])
+        account_info = self._execute_task(proxy=proxy, action='get_info')
+        account_name = account_info['name']
 
         self._account = self.ovc.account_get(account_name, create=False)
         return self._account
-
-    def get_account(self):
-        """ Return account service name """
-
-        self.state.check('actions', 'install', 'ok')
-        return self.data['account']
 
     @property
     def space(self):
@@ -96,7 +96,7 @@ class Vdc(TemplateBase):
         self._space = self.account.space_get(name=self.data['name'], create=False)
         return self._space
 
-    def get_users(self, refresh=True):
+    def _get_users(self, refresh=True):
         """
         Fetch authorized vdc users
         """
@@ -123,7 +123,7 @@ class Vdc(TemplateBase):
 
         if not self.data['create']:
             space = self.space
-            self.get_users(refresh=False)
+            self._get_users(refresh=False)
             self.data['cloudspaceID'] = space.model['id']
             self.state.set('actions', 'install', 'ok')
             return
@@ -148,7 +148,7 @@ class Vdc(TemplateBase):
         # add space ID to data
         self.data['cloudspaceID'] = space.model['id']
         # fetch list of authorized users to self.data['users']
-        self.get_users(refresh=False)
+        self._get_users(refresh=False)
 
         # update capacity incase cloudspace already existed update it
         space.model['maxMemoryCapacity'] = self.data.get('maxMemoryCapacity', -1)
@@ -177,23 +177,11 @@ class Vdc(TemplateBase):
         if not self.data['create']:
             raise RuntimeError('readonly cloudspace')
 
-        self.space.delete()
-        
-        # uninstall vm's on the vdc
-        nodes = self.api.services.find(template_uid=self.NODE_TEMPLATE)
-        for node in nodes:
-            task = node.schedule_action('get_space')
-            task.wait()
-            if task.result == self.name:
-                node.schedule_action('uninstall')
-
-        # uninstall disks on the vdc
-        disks = self.api.services.find(template_uid=self.DISK_TEMPLATE)
-        for disk in disks:
-            task = disk.schedule_action('get_space')
-            task.wait()
-            if task.result == self.name:
-                disk.schedule_action('uninstall')
+        # check if space exists on account
+        for space in self.account.spaces:
+            if space.model['name'] == self.data['name']:
+                self.space.delete()
+                break
 
         self.state.delete('actions', 'install')
 
@@ -242,9 +230,8 @@ class Vdc(TemplateBase):
         self.state.check('actions', 'install', 'ok')
 
         proxy = self._get_proxy(self.NODE_TEMPLATE, node_service)
-        task = proxy.schedule_action('get_id')
-        task.wait()
-        machine_id = task.result
+        node_info = self._execute_task(proxy=proxy, action='get_info')
+        machine_id = node_info['id']
 
         # add portforwards
         for port in ports:
@@ -268,9 +255,8 @@ class Vdc(TemplateBase):
         self.state.check('actions', 'install', 'ok')
 
         proxy = self._get_proxy(self.NODE_TEMPLATE, node_service)
-        task = proxy.schedule_action('get_id')
-        task.wait()
-        machine_id = task.result
+        node_info = self._execute_task(proxy=proxy, action='get_info')
+        machine_id = node_info['id']
 
         existent_ports = [(port['publicPort'], port['localPort'], port['id'])
                             for port in self.ovc.api.cloudapi.portforwarding.list(
@@ -290,17 +276,6 @@ class Vdc(TemplateBase):
                         machineId=machine_id,
                     )
 
-    def _fetch_user_name(self, service_name):
-        """
-        Get vdcuser name. Succeed only if vdcuser service is installed.
-        :param service_name: name of the vdc service 
-        """
-
-        vdcuser = self._get_proxy(self.VDCUSER_TEMPLATE, service_name)
-        task = vdcuser.schedule_action('get_name')
-        task.wait()
-        return task.result
-
     def user_authorize(self, vdcuser, accesstype='R'):
         """
         Add/Update user access to a space
@@ -313,10 +288,12 @@ class Vdc(TemplateBase):
             raise RuntimeError('readonly cloudspace')
         
         # fetch list of authorized users to self.data['users']
-        users = self.get_users()
+        users = self._get_users()
 
         # derive service name from username
-        name = self._fetch_user_name(vdcuser)
+        vdcuser = self._get_proxy(self.VDCUSER_TEMPLATE, vdcuser)
+        user_info = self._execute_task(proxy=vdcuser, action='get_info')
+        name = user_info['name']
 
         for existent_user in users:
             if existent_user['name'] != name:
@@ -357,10 +334,12 @@ class Vdc(TemplateBase):
         self.state.check('actions', 'install', 'ok')
         
         # fetch user name from the vdcuser service
-        username = self._fetch_user_name(vdcuser)
+        vdcuser = self._get_proxy(self.VDCUSER_TEMPLATE, vdcuser)
+        user_info = self._execute_task(proxy=vdcuser, action='get_info')
+        username = user_info['name']
 
         # get user access on the cloudspace
-        users = self.get_users()
+        users = self._get_users()
 
         for user in users:
             if username == user['name']:

--- a/templates/vdc/vdc.py
+++ b/templates/vdc/vdc.py
@@ -12,6 +12,7 @@ class Vdc(TemplateBase):
     ACCOUNT_TEMPLATE = 'github.com/openvcloud/0-templates/account/0.0.1'
     VDCUSER_TEMPLATE = 'github.com/openvcloud/0-templates/vdcuser/0.0.1'
     NODE_TEMPLATE = 'github.com/openvcloud/0-templates/node/0.0.1'
+    DISK_TEMPLATE = 'github.com/openvcloud/0-templates/disk/0.0.1'
 
     def __init__(self, name, guid=None, data=None):
         super().__init__(name=name, guid=guid, data=data)
@@ -177,6 +178,22 @@ class Vdc(TemplateBase):
             raise RuntimeError('readonly cloudspace')
 
         self.space.delete()
+        
+        # uninstall vm's on the vdc
+        nodes = self.api.services.find(template_uid=self.NODE_TEMPLATE)
+        for node in nodes:
+            task = node.schedule_action('get_space')
+            task.wait()
+            if task.result == self.name:
+                node.schedule_action('uninstall')
+
+        # uninstall disks on the vdc
+        disks = self.api.services.find(template_uid=self.DISK_TEMPLATE)
+        for disk in disks:
+            task = disk.schedule_action('get_space')
+            task.wait()
+            if task.result == self.name:
+                disk.schedule_action('uninstall')
 
         self.state.delete('actions', 'install')
 

--- a/templates/vdcuser/vdcuser.py
+++ b/templates/vdcuser/vdcuser.py
@@ -2,6 +2,7 @@ from js9 import j
 from zerorobot.template.base import TemplateBase
 from zerorobot.template.state import StateCheckError
 
+
 class Vdcuser(TemplateBase):
 
     version = '0.0.1'
@@ -27,9 +28,11 @@ class Vdcuser(TemplateBase):
         Get proxy object of the service of type @template_uid with name @service_name
         '''
 
-        matches = self.api.services.find(template_uid=template_uid, name=service_name)
+        matches = self.api.services.find(
+            template_uid=template_uid, name=service_name)
         if len(matches) != 1:
-            raise RuntimeError('found %d services with name "%s", required exactly one' % (len(matches), service_name))
+            raise RuntimeError('found %d services with name "%s", required exactly one' % (
+                len(matches), service_name))
         return matches[0]
 
     def _execute_task(self, proxy, action, args={}):
@@ -37,10 +40,10 @@ class Vdcuser(TemplateBase):
         task.wait()
         if task.state is not 'ok':
             raise RuntimeError(
-                    'error occurred when executing action "%s" on service "%s"' %
-                    (action, proxy.name))
+                'error occurred when executing action "%s" on service "%s"' %
+                (action, proxy.name))
         return task.result
-        
+
     @property
     def ovc(self):
         '''
@@ -50,17 +53,16 @@ class Vdcuser(TemplateBase):
             # get ovc instance name
             proxy = self._get_proxy(self.OVC_TEMPLATE, self.data['openvcloud'])
             ovc_info = self._execute_task(proxy=proxy, action='get_info')
-            self._ovc_instance = j.clients.openvcloud.get(ovc_info['name'])            
+            self._ovc_instance = j.clients.openvcloud.get(ovc_info['name'])
 
         return self._ovc_instance
-
 
     def get_info(self):
         """ Return vdcuser info """
         self.state.check('actions', 'install', 'ok')
         return {
-            'name' : self._get_fqid(),
-            'groups' : self.data['groups'],
+            'name': self._get_fqid(),
+            'groups': self.data['groups'],
         }
 
     def _get_fqid(self):
@@ -74,7 +76,7 @@ class Vdcuser(TemplateBase):
         '''
         Install vdcuser
         '''
-        
+
         try:
             self.state.check('actions', 'install', 'ok')
             return
@@ -104,7 +106,7 @@ class Vdcuser(TemplateBase):
     def uninstall(self):
         """
         unauthorize user to all consumed vdc
-        """      
+        """
         client = self.ovc
         try:
             username = self._get_fqid()


### PR DESCRIPTION
closes #110 
closes #100 
closes #101 - fixes comment related to tests
closes #83 - fixes remaining bullet points

* add retry decorators to `install` actions.
* fix logic of uninstall actions: can't uninstall account and vdc if not empty
* add missing checks
* define methods `_execute_task` and `_get_proxy` for each template to avoid repeating code checking status of tasks and success of finding a service.
* define `get_info` method for each template. Method returns dict of service private info that can be requested by other services. Method is substitution for methods like `get_name`, `get_id` etc, present in the code before.